### PR TITLE
Emphasize importance of deploying after merge

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -8,7 +8,7 @@ Ensure [pt-flow](https://github.com/balvig/pt-flow) is installed and up to date 
 2. `git finish` if done to submit a pull request for [code review](/code-review)
 3. After completing code review merge in GitHub and _deploy_
 
-**NOTE:** It is vital to deploy right after merging new code, so that _you_ can follow up on any bugs/performance issues, instead of it becoming the problem of the next person to deploy.
+**NOTE:** It is vital to deploy right after merging new code, so that _you_ can follow up on any bugs/issues, instead of it becoming the problem of the next person to deploy.
 
 ## WIP branches
 


### PR DESCRIPTION
Past couple of days has seen a couple of PRs that were merged, but not immediately deployed.

This leaves any potential issues as nice little surprises for the next deployer to discover and fix! :sweat_smile:

Even after getting a :+1:, if you aren't going to be around when the code gets deployed, it's probably better to wait to merge till a time where you can follow up on any problems that might occur 🙏 
