### PR TITLE
Should format source code for 100 characters

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -1,3 +1,7 @@
+## Formatting
+
+- You should format source code so that no line is longer than 100 characters
+
 ## SCSS
 
 - Use [BEM & OOCSS](/best-practices/bem)


### PR DESCRIPTION
Some line length restriction is better than none at all. While old text terminals used to make 80 columns the standard, these days, allowing 100 columns seems better, since good style encourages the use of descriptive variables and method names.

~115~ 119 is the length we don't need to scroll on GitHub PR diff. But ~~115~~ 119 maybe too much for people who use 12" / 13" laptop, so let's do 100!

Discussion: https://github.com/cookpad/global-web/pull/4145