### PR TITLE
Revert "Should format source code for 100 characters"

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -1,7 +1,3 @@
-## Formatting
-
-- You should format source code so that no line is longer than 100 characters
-
 ## SCSS
 
 - Use [BEM & OOCSS](/best-practices/bem)


### PR DESCRIPTION
Reverts cookpad/guides#18

Leave to hound.