### PR TITLE
Add have_text preference in our guides

### DIFF
--- a/best-practices/rspec/README.md
+++ b/best-practices/rspec/README.md
@@ -121,3 +121,7 @@ end
 - Use [TimeCop](https://github.com/travisjeffery/timecop) to mock and test methods that relies on time.
 - Use [Webmock](https://github.com/bblimke/webmock) to mock HTTP calls to remote service that could not be available all the time and that you want to personalize.
 - Use [rspec_api_documentation](https://github.com/zipmark/rspec_api_documentation) to write API specs, it'll generate api docs automatically.
+- <a name="have_text"></a>
+  Prefer `have_text` over `have_content` [Background][web-4154]
+  <sup>[[link](#have_text)]</sup>
+  [web-4154]: https://github.com/cookpad/global-web/pull/4154


### PR DESCRIPTION
Follow up of https://github.com/cookpad/global-web/pull/4154#issuecomment-259576941.

[Preview here](https://github.com/cookpad/guides/blob/fcb0b77/best-practices/rspec/README.md#have_text)

After this PR merged, you can use this link to refer:

```
https://github.com/cookpad/guides/blob/master/best-practices/rspec/README.md#have_text
```

