### PR TITLE
Formalize flow for making development suggestions

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -31,8 +31,10 @@ branch_.  Reviewers will then be able to review each _smaller_ PR as they come i
 
 ## Discussions and ideas around development
 
-- New ideas on how we can improve our development flow are always welcome
+New ideas on how we can improve our development flow are always welcome!
+
 - Avoid making proposals for new coding styles inside story-based PRs
 - When proposing a change or new concept, submit an issue or isolated PR on GitHub
 - Clearly show the before/after and any pain points that inspired the proposal
+- Allow the issue or PR to sit long enough for everyone to have a look
 - The [kaizen board](https://trello.com/b/dpyiKTut/kaizen) is a good place to go for "known pain points"


### PR DESCRIPTION
Recently it's been really great to see different opinions and suggestions pop up from new members of the team, and also reevaluate past decisions made by existing members! 🍰 🍰 🍰 

However, sometimes this process can get a bit chaotic, and proposals for new ways of doing things might happen inside PRs that are trying to solve an actual user-facing problem, thus delaying the release of said PR (ie https://github.com/cookpad/global-web/pull/4143 😅)

This PR tries to "formalize" the flow a bit, by adding some tips in the guides on how/where to make suggestions of this sort.

I realize that some of this will inevitably happen organically through the actual work, so I guess the below is more of an aspiration than a hard rule.