### PR TITLE
Prefer method invocation over instance variables

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -1,3 +1,7 @@
+## Ruby
+
+- [Prefer method invocation over instance variables](samples/ruby/1.rb)
+
 ## Rails
 
 - Prefer Time.current over Time.now

--- a/best-practices/samples/ruby/1.rb
+++ b/best-practices/samples/ruby/1.rb
@@ -1,0 +1,27 @@
+## Bad
+
+class MarkRecipe
+  def initialize(recipe)
+    @recipe = recipe
+  end
+
+  def run
+    @recipe.mark
+  end
+end
+
+## Good
+
+class MarkRecipe
+  def initialize(recipe)
+    @recipe = recipe
+  end
+
+  def run
+    recipe.mark
+  end
+
+  private
+
+    attr_reader :recipe
+end


### PR DESCRIPTION
- Avoid typos
  For example we have a instance variable `@misspelling`,
`@mispelling` will silently return nil, while `attr_reader` + `mispelling` will raise `NoMethodError`.
- Remove duplications of the need to type `@`
  [for example in this file](https://github.com/cookpad/global-web/blob/bcb00a73f9be418ebaf821fb3461a135ff619b35/app/models/moderation/evaluation/bad_recipe_content.rb)
- uniform access principle
  If you make them methods now, you won’t have to change them to methods later when requirements change.