### PR TITLE
Prefer `have_text` over `have_content`

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -29,6 +29,7 @@
 - [Avoid using `let`](samples/testing/3.rb)
 - [Avoid adding dummy data that is not asserted in the spec](samples/testing/2.rb)
 - Only enable `:js` when the feature absolutely requires javascript
+- [Prefer `have_text` over `have_content`](https://github.com/cookpad/global-digging/issues/2)
 
 ## I18n
 


### PR DESCRIPTION
Follow up to https://github.com/cookpad/guides/pull/21 (which is out of sync with master at this point)

cc @JuanitoFatas 