### PR TITLE
Do not use should when describing your tests

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -32,6 +32,7 @@
 - Only enable `:js` when the feature absolutely requires javascript
 - [Prefer `have_text` over `have_content`](https://github.com/cookpad/global-digging/issues/2)
 - [Prefer "descriptive" dummy data over realistic dummy data](samples/testing/4.rb)
+- [Do not use _should_ when describing your tests](samples/testing/5.rb)
 
 ## I18n
 

--- a/best-practices/samples/testing/5.rb
+++ b/best-practices/samples/testing/5.rb
@@ -1,0 +1,39 @@
+## Bad
+
+it "should deliver email" do
+end
+
+it "should not deliver email when user prints a recipe" do
+end
+
+it "should only send email that has been activated" do
+end
+
+it "should be enabled" do
+end
+
+it "should have custom headers" do
+end
+
+it "should by default be true" do
+end
+
+## Good
+
+it "delivers email" do
+end
+
+it "does not deliver email when user prints a recipe" do
+end
+
+it "only sends email that has been activated" do
+end
+
+it "is enabled" do
+end
+
+it "has custom headers" do
+end
+
+it "defaults to true" do
+end


### PR DESCRIPTION
Related PR: https://github.com/cookpad/global-web/pull/5140

This is one of the [RSpec best practices](http://betterspecs.org/#should):

> Do not use should when describing your tests. Use the third person in the present tense.