### PR TITLE
Document variable naming convention in JS

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -440,6 +440,22 @@
   Avoid using `.classes` as selectors (they are for styling). Use `[data-behavior~=]`, `[data-*]`, or `#ids`.
   <sup>[link](#avoid-using-classes-in-js)</sup>
 
+- <a name="use-camelcase-in-js"></a>
+  Use `camelCase`, not `snake_case` in Javascript
+  <sup>[link](#use-camelcase-in-js)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```js
+    // Bad
+    let recipe_link = event.currentTarget
+
+    // Good
+    let recipeLink = event.currentTarget
+    ```
+  </details>
+
 ## Testing
 
 - <a name="prefer-explicitness"></a>


### PR DESCRIPTION
In isolation I prefer `snake_case`, but feel like consistency is better when dealing with JS!