### PR TITLE
Enforce rails style indentation for private methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -120,7 +120,7 @@ Style/IfWithSemicolon:
   Enabled: false
 
 Layout/IndentationConsistency:
-  Enabled: false
+  EnforcedStyle: rails
 
 Style/InlineComment:
   Enabled: false


### PR DESCRIPTION
We are following the style of the Rails code base by indenting private methods. Rubocop has an option to enforce that. However, we currently have that cop disabled

The problem is that with the newest version of Rubocop, we are having _thousands_ of offenses from another cop, `IndentationWidth`, which warns us that we should use 2 spaces instead of 4.

If we enforce the rails style here, it will warn us about the places where it's not indented, **and** we will get the other cop to calculate the correct width according to the Rails style.