### PR TITLE
Add conventions about testing endpoints

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -371,13 +371,17 @@
   </details>
   
 - <a name="testing-endpoints"></a>
-  Do not use the `document` meta tag when writing tests for endpoints
+  Do not use the `document` meta tag when writing tests for endpoints. Tests in the
+  `specs/requests/api/` path are intended to create documentation for endpoints but to 
+  test the assert on the endpoint response or side-effects.
   <sup>[link](#testing-endpoints)</sup>
 
   <details>
     <summary><em>Example</em></summary>
 
     ```ruby
+    ## spec/requests/api/bookmarks_spec.rb
+    
     ## Bad
     resource "Bookmarks" do
       get "/:version/users/:user_id/bookmarks" do
@@ -410,6 +414,8 @@
     <summary><em>Example</em></summary>
 
     ```ruby
+    ## spec/requests/docs/bookmarks_spec.rb
+    
     ## Bad
     resource "Bookmarks" do
       get "/:version/users/:user_id/bookmarks" do

--- a/testing/README.md
+++ b/testing/README.md
@@ -369,3 +369,86 @@
     expect(Recipe.recently_published.last).to eq(older_recipe)
     ```
   </details>
+  
+- <a name="testing-endpoints"></a>
+  Do not use the `document` meta tag when writing tests for endpoints
+  <sup>[link](#testing-endpoints)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    ## Bad
+    resource "Bookmarks" do
+      get "/:version/users/:user_id/bookmarks" do
+        example "lists bookmarks for a user with specific IDs", document: true do
+          # ...
+        end
+      end
+    end
+
+    ## Good
+    resource "Bookmarks" do
+      get "/:version/users/:user_id/bookmarks" do
+        example "lists bookmarks for a user with specific IDs" do
+          # ...
+        end
+      end
+    end
+    ```
+  </details>
+
+- <a name="document-endpoints"></a>
+  Document endpoints creating tests in the `specs/requests/docs/` path. These tests 
+  should be simple and not focus on asserting on side effects or asserting specific
+  values in the response, Use regular request tests for that. Make sure you document 
+  every `parameter`, `header`, the `response_field` and make an assertion on the
+  response `status`. More details on what can be documented [here](https://github.com/zipmark/rspec_api_documentation#explanation).
+  <sup>[link](#document-endpoints)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    ## Bad
+    resource "Bookmarks" do
+      get "/:version/users/:user_id/bookmarks" do
+        example "List bookmarks" do
+          user = create(:user)
+          recipe = create(:recipe, title: "Recipe Title")
+          create(:bookmark, user: user, recipe: recipe)
+          set_auth_header user
+          
+          do_request user_id: user.id, query: "title", strategy, ids: [1, 2]
+          
+          expect_json_response("result/0/recipe").to include(title: "Recipe Title")
+          expect_json_response("extra").to include(total_count: 1)
+        end
+      end
+    end
+
+    ## Good
+    resource "Bookmarks" do
+      explanation "Bookmarks are recipes a user saves. They can be fetched when the user is signed-in"
+      
+      get "/:version/users/:user_id/bookmarks" do
+        parameter :query, "Search keyword"
+        parameter :strategy, "Either default 'incremental' or 'analyzed'"
+        parameter :ids, "Comma delimited list of bookmark IDs '1,2,3'"
+        
+        response_field "A list of bookmarks"
+        
+        example "Responds with a list of bookmarks for the given user" do
+          user = create(:user)
+          recipe = create(:recipe, title: "Recipe Title")
+          create(:bookmark, user: user, recipe: recipe)
+          set_auth_header user
+          
+          do_request user_id: user.id, query: "title", strategy, ids: [1, 2]
+          
+          expect(status).to eq(200)
+        end
+      end
+    end
+    ```
+  </details>


### PR DESCRIPTION
I am suggesting the following:

- Let's keep using `example` everywhere for request specs. Splitting between `it` and `example` only made sense when tests were mixed in the same file. Now that documenting tests go in a separate file there's no point in using a different part of the DSL which [have the same effect](https://github.com/zipmark/rspec_api_documentation#example).
- Let's stop using `document: true`. AFAIK the `document` meta tag is not really being used to pick tests will be included in the documentation and which not. Moving forward we will choose the test that should generate documentation based on the path they're in so there's even less reason to use the meta tag.
- Let's make it a requirement to not only start adding _documenting tests_ for new endpoints but also to document their parameters and response. The point of creating documentation is for it to be complete, not just a list of available endpoints that client applications need to start guessing how to use them

@cookpad/global-search what do you think about starting to document you API? AFAIK there's no documentation for the API we use to connect `global-web` to `global-search` every time I need to integrate with `global-search` I need to talk to someone working on that application to check if the endpoint I need already exists and how to use it. I'd be happy to help get you started.

@davidstosik what do you think about doing the same for `global-payments`?