### PR TITLE
Remove easily misinterpreted mention of "explicitness"

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -1,8 +1,8 @@
 # Testing
 
-- <a name="prefer-explicitness"></a>
-  Prefer explicitness in specs: Avoid using `subject`, `described_class`, `shared_examples`, `shared_context`
-  <sup>[link](#prefer-explicitness)</sup>
+- <a name="avoid-subject-and-friends"></a>
+  Avoid using `subject`, `described_class`, `shared_examples`, `shared_context`
+  <sup>[link](#avoid-subject-and-friends)</sup>
 
 - <a name="avoid-using-context"></a>
   Avoid using `context`


### PR DESCRIPTION
See thread [here](https://github.com/cookpad/global-web/pull/8384#issue-197894937) for some context on the confusion that line was causing 😅 

cc @sebasoga @sikachu @karlentwistle 