### PR TITLE
Add testing guide about writing tiny specs

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -370,7 +370,7 @@
     ```
   </details>
   
-  - <a name="use-minutes"></a>
+- <a name="use-minutes"></a>
   Prefer splitting up longer specs into tinier ones, even if they require the same setup
   <sup>[link](#use-minutes)</sup>
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -370,8 +370,8 @@
     ```
   </details>
   
-- <a name="use-minutes"></a>
-  Prefer splitting up longer specs into tinier ones, even if they require the same setup
+- <a name="split-long-specs"></a>
+  Prefer splitting up longer specs and give each scenario its own spec, even if they require a similar setup
   <sup>[link](#use-minutes)</sup>
 
   <details>

--- a/testing/README.md
+++ b/testing/README.md
@@ -369,3 +369,49 @@
     expect(Recipe.recently_published.last).to eq(older_recipe)
     ```
   </details>
+  
+  - <a name="use-minutes"></a>
+  Prefer splitting up longer specs into tinier ones, even if they require the same setup
+  <sup>[link](#use-minutes)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    ## Bad
+    it "sanitizes recipe titles" do
+      recipe = build(:recipe, title: "recipe title without capital letter")
+      expect(recipe.title).to eq("Recipe title without capital letter")
+    
+      recipe = build(:recipe, title: "Recipe title with period Brand Name v1.0. ")
+      expect(recipe.title).to eq("Recipe title with period Brand Name v1.0")
+
+      recipe = build(:recipe, title: "Recipe title ( very good   )")
+      expect(recipe.title).to eq("Recipe title (very good)")
+
+      recipe = build(:recipe, title: 'Recipe title " very good   "')
+      expect(recipe.title).to eq('Recipe title "very good"')
+    end
+
+    ## Good
+    it "capitalizes the first letter in recipe titles" do
+      recipe = build(:recipe, title: "recipe title without capital letter")
+      expect(recipe.title).to eq("Recipe title without capital letter")
+    end
+    
+    it "removes full stop from recipe titles" do
+      recipe = build(:recipe, title: "Recipe title with period Brand Name v1.0. ")
+      expect(recipe.title).to eq("Recipe title with period Brand Name v1.0")
+    end
+    
+    it "removes spaces inside parens from recipe titles" do
+      recipe = build(:recipe, title: "Recipe title ( very good   )")
+      expect(recipe.title).to eq("Recipe title (very good)")
+    end
+
+    it "removes spaces inside quotes from recipe titles" do
+      recipe = build(:recipe, title: 'Recipe title " very good   "')
+      expect(recipe.title).to eq('Recipe title "very good"')
+    end
+    ```
+  </details>


### PR DESCRIPTION
Worked in this with @balvig during our pairing session earlier this week. We wanted to add this convention which we extracted from this PR: https://github.com/cookpad/global-web/pull/6019.