### PR TITLE
Enforce memoized instance variable name with leading underscore

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -306,7 +306,7 @@ Style/PercentLiteralDelimiters:
     "%x": ()
 
 Naming/MemoizedInstanceVariableName:
-  Enabled: false
+  EnforcedStyleForLeadingUnderscores: required
 
 Rails/Output:
   Enabled: true


### PR DESCRIPTION
After upgrading to RuboCop 0.58.0 we can use a [new configuration option](https://github.com/rubocop-hq/rubocop/pull/5844) to enforce a leading underscore on memoized instance variable names 

See also https://github.com/cookpad/global-style-guides/pull/74

Thanks to @kinopyo for the reminder! 🙇 