### PR TITLE
Remove rule covered by RuboCop

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -131,31 +131,6 @@
     ```
   </details>
 
-- <a name="memoized-instance-variable-name"></a>
-  In memoized methods, use an instance variable that matches the method name prefixed with an underscore
-  <sup>[link](#memoized-instance-variable-name)</sup>
-
-  <details>
-    <summary>Example</summary>
-
-    ```ruby
-    ## Bad
-    def author
-      @_user ||= User.find(params[:id])
-    end
-
-    ## Bad
-    def author
-      @author ||= User.find(params[:id])
-    end
-
-    ## Good
-    def author
-      @_author ||= User.find(params[:id])
-    end
-    ```
-  </details>
-
 - <a name="explanatory-constants"></a>
   Describe unexplained strings/numbers using constants
   <sup>[link](#explanatory-constants)</sup>


### PR DESCRIPTION
Since we now have automated checking of this thanks to https://github.com/cookpad/global-style-guides/pull/101, I think we can now remove this from the written guide.

(the "use the same name"-part perhaps isn't checked by rubocop, but maybe we can see how that goes)