### PR TITLE
Update testing style guides to include rules on the expect to change Rspec syntax

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -415,3 +415,27 @@
     end
     ```
   </details>
+
+- <a name="not-user-expect-change-by"></a>
+  Do not use the `expect` .. `change` syntax with `by`. Use `from` and `to` instead.
+  <sup>[link](#not-user-expect-change-by)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    ## Bad
+    it "increment recipe counters" do
+      recipe = create(:recipe)
+       
+      expect{ create(:photo_comment) }.to change{ recipe.reload.photo_comments_count }.by(1)
+    end
+
+    ## Good
+    it "increment recipe counters" do
+      recipe = create(:recipe)
+       
+      expect{ create(:photo_comment) }.to change{ recipe.reload.photo_comments_count }.from(0).to(1)
+    end
+    ```
+  </details>


### PR DESCRIPTION
I have recently been fixing a bug on the counter which was incrementing the recipe photo_comment count using `dismissed` new comments, and then re-incrementing when the comment gets `active`. The issue ended up with the photo comment being counted twice in the recipe rather than once. 
The test was there, but since it was using the `expect` `change` Rspec syntax with a `by(1)`, we haven't noticed that the counter which should have been going from 0 to 1, was actually going from 1 to 2. 
Hence, I believe is valuable to add this to our testing style guide