### PR TITLE
Enable Lint/Void cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -280,7 +280,7 @@ Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
 Lint/Void:
-  Enabled: false
+  Enabled: true
 
 Lint/UselessAssignment:
   Exclude:


### PR DESCRIPTION
I was playing with RuboCop, forcing it to check offenses that we currently have disabled, and I found this cop particularly interesting because it actually discovered bugs in our specs: https://github.com/cookpad/global-web/pull/9181

I didn't enable the additional option `CheckForMethodsWithNoSideEffects` because it was reporting false positives with Capybara's `select` method.