### PR TITLE
Fix example about HTML in translations

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -280,12 +280,12 @@
     ## Good
     current_time:
       label: "Current time:"
-      label_time: "%{label} %{time}"
+      label_time_html: "%{label} %{time}"
     ```
 
     ```erb
     <!-- Good -->
-    <%= t("current_time.label_time", label: content_tag(:strong, t("current_time.label")), time: Time.current) %>
+    <%= t("current_time.label_time_html", label: content_tag(:strong, t("current_time.label")), time: Time.current) %>
     ```
   </details>
 


### PR DESCRIPTION
Just a small fix to the example. The key has to end with '_html' or the `<strong>` tag will be escaped.

https://guides.rubyonrails.org/i18n.html#using-safe-html-translations