### PR TITLE
Clarify git force push rule

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -1,9 +1,10 @@
 # Git
 
-- <a name="use-merge-instead-of-rebase-when-collaborating"></a>
-  When syncing with master, if the branch is under PR review or being collaborated on,
-  use `merge` instead of `rebase` to avoid losing relevant context/breaking other local branches
-  <sup>[link](#use-merge-instead-of-rebase-when-collaborating)</sup>
+- <a name="avoid-force-push-when-collaborating"></a>
+  If a branch is under PR review or being collaborated on, avoid using force push
+  to prevent losing context or breaking other local branches.
+  Once the PR is ready for merge, feel free to squash as needed.
+  <sup>[link](#avoid-force-push-when-collaborating)</sup>
 
 - <a name="dont-push-large-data"></a>
   Don't push temporary data files or big binary files to GitHub.


### PR DESCRIPTION
From discussion in Slack: https://ckpd.slack.com/archives/C06B9GD9D/p1542162657497600

It can actually be useful to follow those little "renamed X to Y" commits _while the PR is under review_.

Once approved though, squashing up any noisy commits is encouraged.