### PR TITLE
Add another BEM reference

### DIFF
--- a/scss/bem/README.md
+++ b/scss/bem/README.md
@@ -111,6 +111,7 @@ We try to have as much as possible of:
 
 ## Useful links
 
+- https://en.bem.info/methodology/quick-start/
 - http://fullstackradio.com/episodes/1/
 - https://mattstauffer.co/blog/organizing-css-oocss-smacss-and-bem
 - https://css-tricks.com/bem-101/

--- a/scss/bem/README.md
+++ b/scss/bem/README.md
@@ -111,7 +111,7 @@ We try to have as much as possible of:
 
 ## Useful links
 
-- https://en.bem.info/methodology/quick-start/
+- https://en.bem.info/methodology/quick-start Gotcha: ignore `block__element_modifier` and use `block__element--modifier` instead
 - http://fullstackradio.com/episodes/1/
 - https://mattstauffer.co/blog/organizing-css-oocss-smacss-and-bem
 - https://css-tricks.com/bem-101/


### PR DESCRIPTION
I find this documentation to be a really clear and well-written reference for using BEM. 
Thanks to @sikachu for finding it!

One gotcha is that it endorses `block__element_modifier` rather than `block__element--modifier` which we use, so just watch out for that 😓 