### PR TITLE
Changes flipFlop from style to lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,7 +98,7 @@ Style/EvenOdd:
 Naming/FileName:
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Enabled: false
 
 Style/FormatString:


### PR DESCRIPTION
Because it was moved: https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes point 3