### PR TITLE
Add guide for 'Separate multiline fetch/query methods from the memoize method'

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -241,10 +241,10 @@
 
     ## Good
     def pizza_recipes
-      @_pizza_recipes ||= query_pizza_recipes
+      @_pizza_recipes ||= fetch_pizza_recipes
     end
 
-    def query_pizza_recipes
+    def fetch_pizza_recipes
       Recipe.
         published.
         in_current_language.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -222,3 +222,33 @@
     end
     ```
   </details>
+
+- <a name="separate-multiline-fetch-method"></a>
+  Separate multiline fetch/query methods from the memoized method
+  <sup>[link](#separate-multiline-fetch-method)</sup>
+
+  <details>
+    <summary>Example</summary>
+
+    ```ruby
+    ## Bad
+    def pizza_recipes
+      @_pizza_recipes ||= Recipe.
+        published.
+        in_provider.
+        where("title LIKE ?", "%pizza%")
+    end
+
+    ## Good
+    def pizza_recipes
+      @_pizza_recipes ||= query_pizza_recipes
+    end
+
+    def query_pizza_recipes
+      Recipe.
+        published.
+        in_provider.
+        where("title LIKE ?", "%pizza%")
+    end
+    ```
+  </details>

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -235,7 +235,7 @@
     def pizza_recipes
       @_pizza_recipes ||= Recipe.
         published.
-        in_provider.
+        in_current_language.
         where("title LIKE ?", "%pizza%")
     end
 
@@ -247,7 +247,7 @@
     def query_pizza_recipes
       Recipe.
         published.
-        in_provider.
+        in_current_language.
         where("title LIKE ?", "%pizza%")
     end
     ```


### PR DESCRIPTION
A recent [comment on one of my PR](https://github.com/cookpad/global-web/pull/11448#discussion_r261179270) made me realize that this rule was not added in our guide even though there was a discussion about it https://github.com/cookpad/global-web/issues/9372#issuecomment-425327541 I don't think there was a decision about the style but hopefully this would help!