### PR TITLE
Exclude specs from module length cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,10 @@ Metrics/LineLength:
   Exclude:
     - spec/**/*
 
+Metrics/ModuleLength:
+  Exclude:
+    - spec/**/*
+
 Rails:
   Enabled: true
 


### PR DESCRIPTION
Wrapping specs in a module is a useful little trick to avoid having to refer to a namespace over and over again when testing namespaced classes:

```rb
RSpec.describe LongishNamespace::Notification do
  describe "#create" do
    it "works" do
      LongishNamespace::Notification.create!

      expect(LongishNamespace::Notification.count).to eq(1)
    end
  end
end
```

vs

```rb
module LongishNamespace
  RSpec.describe Notification do
    describe "#create" do
      it "works" do
        Notification.create

        expect(Notification.count).to eq(1)
      end
    end
  end
end
```

This unfortunately sets off Rubocop though:

<img width="452" alt="screen shot 2019-03-08 at 13 45 43" src="https://user-images.githubusercontent.com/104138/54008103-826cf280-41a8-11e9-96e0-cf04c74de596.png">

**RSpec rant:** Incidentally, this is one of those things that would "just work" with plain TestUnit (along with [this](https://github.com/cookpad/global-style-guides/commit/5e77fbba719acdf7a5aae1759ba1cbda9dd0325d)), since it would be plain Ruby without the `RSpec.describe` block:

```rb
module LongishNamespace
  class NotificationTest < ActiveSupport::TestCase
    test "create works" do
      Notification.create!

      assert_equal 1, Notification.count
    end
  end
end
```