### PR TITLE
Adopt the arrange, act, assert pattern for specs

### DIFF
--- a/rspec/README.md
+++ b/rspec/README.md
@@ -445,7 +445,7 @@
     ```
   </details>
 - <a name="arrange-act-assert"></a>
-  Lay out specs according to the [Arrange, Act, Assert](http://wiki.c2.com/?ArrangeActAssert) pattern.
+  Lay out specs according to the [Arrange, Act, Assert](http://wiki.c2.com/?ArrangeActAssert) pattern. Each test should group these functional sections, separated by blank lines.
   <sup>[link](#arrange-act-assert)</sup>
 
   <details>

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -445,7 +445,7 @@
     ```
   </details>
 - <a name="arrange-act-assert"></a>
-  Lay out specs according to the [Arrange, Act, Assert](http://wiki.c2.com/?ArrangeActAssert) pattern. Each test should group these functional sections, separated by blank lines.
+  Lay out specs according to the [Arrange, Act, Assert](http://wiki.c2.com/?ArrangeActAssert) pattern. Each test should group these functional sections, separated by blank lines. You may also need to add a fourth teardown phase. If so, seperate this section with another blank line.
   <sup>[link](#arrange-act-assert)</sup>
 
   <details>

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -455,9 +455,9 @@
     ## Bad
     it "does something" do
       user = create(:user)
-      
+
       recipe = create(:recipe, user: user)
-      
+
       recipe.delete
       expect(recipe).to be_deleted
     end
@@ -466,7 +466,7 @@
     it "does something" do
       user = create(:user)
       recipe = create(:recipe, user: user)
-      
+
       recipe.delete
 
       expect(recipe).to be_deleted

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -444,3 +444,32 @@
     #  expected #<ActiveRecord::Relation [#<Achievement id: 1, user_id: 104, ...>]> not to exist
     ```
   </details>
+- <a name="arrange-act-assert"></a>
+  Lay out specs according to the [Arrange, Act, Assert](http://wiki.c2.com/?ArrangeActAssert) pattern.
+  <sup>[link](#arrange-act-assert)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    ## Bad
+    it "does something" do
+      user = create(:user)
+      
+      recipe = create(:recipe, user: user)
+      
+      recipe.delete
+      expect(recipe).to be_deleted
+    end
+
+    ## Good
+    it "does something" do
+      user = create(:user)
+      recipe = create(:recipe, user: user)
+      
+      recipe.delete
+
+      expect(recipe).to be_deleted
+    end
+    ```
+  </details>


### PR DESCRIPTION
We generally lay out our specs in this way anyway, this just formalises this in our guide.

Each test should group functional sections, separated by blank lines.