### PR TITLE
Split rubocop-performance

### DIFF
--- a/.rubocop.performance.yml
+++ b/.rubocop.performance.yml
@@ -1,0 +1,5 @@
+Performance/RedundantMerge:
+  Enabled: false
+
+Performance/TimesMap:
+  Enabled: false

--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -259,12 +259,6 @@ Lint/Loop:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
 
-Performance/RedundantMerge:
-  Enabled: false
-
-Performance/TimesMap:
-  Enabled: false
-
 Lint/RequireParentheses:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 inherit_from:
   - .rubocop.ruby.yml
   - .rubocop.rails.yml
+  - .rubocop.performance.yml


### PR DESCRIPTION
This follows https://github.com/cookpad/global-style-guides/pull/128

As the performance rules were extracted away to the [`rubocop-performance`](https://github.com/rubocop-hq/rubocop-performance) gem, it makes sense to extract them to a separate file here too (a project may or may not want to use performance rules and the gem).

This PR is not expected to break any workflow, same as the previous one.

Next steps:
- [x] make sure that our main projects that make use of the `.rubocop.yml` file here have all required dependencies in their Gemfile and/or CI scripts.
  - [x] global-web (https://github.com/cookpad/global-web/pull/13123)
  - [x] global-feeds (https://github.com/cookpad/global-feeds/pull/598)
  - [x] global-newsletters (https://github.com/cookpad/global-newsletters/pull/835)
  - [x] global-payments (https://github.com/cookpad/global-payments/pull/227)
  - [x] global-search (https://github.com/cookpad/global-search/pull/4469)
  - [ ] any other?
- [ ] add `require: rubocop-rails` and `require: rubocop-performance` in the proper files in this repository
- [ ] remove `require:` statements from each project's repository
  - [ ] global-web
  - [ ] global-feeds
  - [ ] global-newsletters
  - [ ] global-payments
  - [ ] global-search
  - [ ] any other?

---

A reminder of the end goal:

- Any project that wants to use our style guides' Rubocop rules will have a `.rubocop.yml` file that starts like this:
    ```yml
    inherit_from:
      - https://raw.githubusercontent.com/cookpad/global-style-guides/master/.rubocop.yml
      # Could be .rubocop.ruby.yml and/or .rubocop.performance.yml for non-Rails projects.

    # No need for `require: rubocop-performance` or `require: rubocop-rails` here.
    ...
    ```
- `global-style-guides` `.rubocop.yml` file only calls out to other Rubocop files (one per gem):
    ```yml
    inherit_from:
      - .rubocop.ruby.yml
      - .rubocop.rails.yml
      - .rubocop.performance.yml
    ```
- Each `.rubocop.#{section}.yml` file has its own `require: ` line when necessary (so far, `rubocop-rails` and `rubocop-performance`).