### PR TITLE
Add `require` for RuboCop modules to their respective files

### DIFF
--- a/.rubocop.performance.yml
+++ b/.rubocop.performance.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 Performance/RedundantMerge:
   Enabled: false
 

--- a/.rubocop.rails.yml
+++ b/.rubocop.rails.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 Rails:
   Enabled: true
 


### PR DESCRIPTION
Now all the Cookpad projects that I know of updated their `Gemfile` to include all the required gems, I can add the `require` lines in the RuboCop config here.

See https://github.com/cookpad/global-style-guides/pull/129.

⚠️ This could break any project referring to `.rubocop.yml` whereas they're not loading the proper dependencies (`rubocop-performance` and `rubocop-rails` gems).