### PR TITLE
Clarify instance variables

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -55,6 +55,10 @@
 
     ## Also acceptable
     class Pager
+      def initialize
+        @current_page = 1
+      end
+
       def run
         while continue?
           # ...
@@ -64,9 +68,7 @@
 
       private
 
-        def current_page
-          @current_page ||= 1
-        end
+        attr_reader :current_page
 
         def go_to_next_page
           @current_page += 1

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -58,18 +58,18 @@
       def run
         while continue?
           # ...
-	  increment_page
+	  go_to_next_page
 	end
       end
 
       private
 
         def current_page
-          @page ||= 1
+          @current_page ||= 1
         end
 
-        def increment_page
-          @page += 1
+        def go_to_next_page
+          @current_page += 1
         end
     end
     ```

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -33,6 +33,25 @@
 
         attr_reader :recipe
     end
+
+    ## Also acceptable
+    class Image
+      def initialize(placeholder: false)
+        @placeholder = placeholder
+      end
+
+      def render
+        if placeholder?
+          # ...
+        end
+      end
+
+      private
+
+        def placeholder?
+          !!@placeholder
+        end
+    end
     ```
   </details>
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -58,8 +58,8 @@
       def run
         while continue?
           # ...
-	  go_to_next_page
-	end
+          go_to_next_page
+        end
       end
 
       private

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -52,6 +52,26 @@
           !!@placeholder
         end
     end
+
+    ## Also acceptable
+    class Pager
+      def run
+        while continue?
+          # ...
+	  increment_page
+	end
+      end
+
+      private
+
+        def current_page
+          @page ||= 1
+        end
+
+        def increment_page
+          @page += 1
+        end
+    end
     ```
   </details>
 


### PR DESCRIPTION
Closes #124 

## Accept instance variable in boolean reader method

This one was discussed in details in #124.

## Accept instance variable in other accessor-like methods

I've had [one more conversation](https://github.com/cookpad/global-web/pull/14537#discussion_r317905384) around this recently with @sikachu. I am unsure of this one, so would like other's opinion. 🙏 

I feel like we want to avoid the use of instance variables _outside of accessor methods_. The simplest example is when we use `attr_reader` to define the reader method silently (still, there is an underlying instance variable, just unseen/untyped).

As mentioned by @balvig in #124, there are a few reasons that lead to this rule:
1. a typo on an instance variable is silent (no failure, harder to notice)
2. if we use instance variables everywhere in a class, then we have to repeat the variable's `@` prefix many times
3. if we need to change the underlying implementation, then we might have to change numerous mentions to that instance variable

I believe that encapsulating an instance variable into accessor-like methods fulfills point number 3 (the instance variable is only located in one or two accessor methods, if we need to change how that value is stored/calculated, then those are the only places where the instance variable needs to be changed).
Even though points 1 and 2 are not entirely fulfilled (I'm suggesting that it might be okay to see a couple mentions to an instance variable in very specific places), I think those risks are limited.

I'm uncertain about the second one, and will gladly debate and arguments against it! Please let me know what you think. 🙏 