### PR TITLE
Add Ruby guide regarding unless with operator

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -252,3 +252,32 @@
     end
     ```
   </details>
+
+- <a name="avoid-unless-with-operator"></a>
+  Avoid `unless` with boolean operator(s) in the conditional
+  <sup>[link](#avoid-unless-with-operator)</sup>
+
+  <details>
+    <summary>Example</summary>
+
+    ```ruby
+    ## Bad
+    unless client_id.present? && client_secret.present?
+      raise "Missing credentials for OauthApplication #{name}."
+    end
+
+    ## Good - flip to if
+    if client_id.blank? || client_secret.blank?
+      raise "Missing credentials for OauthApplication #{name}."
+    end
+
+    ## Good - extract method
+    if missing_credentials?
+      raise "Missing credentials for OauthApplication #{name}."
+    end
+
+    def missing_credentials?
+      client_id.blank? || client_secret.blank?
+    end
+    ```
+  </details>


### PR DESCRIPTION
When using unless, we should avoid using an operator in the conditional. Reasoning behind that the operator also gets negated, leading often to wrong conditionals and harder to understand.

 ```ruby
## Bad
def recipes?
  return false unless foo && bar
end

def recipes?
  return false if !(foo || bar)
end

## Good
def recipes?
  return false unless foo
  return false unless bar
end
```

See https://github.com/cookpad/global-web/pull/14590

PR for a RuboCop https://github.com/rubocop-hq/rubocop/pull/7311