### PR TITLE
Add link to Redis 'styles'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Python](/python)
 - [Rails](/rails)
 - [Rake](/rake)
+- [Redis](/redis)
 - [RSpec](/rspec)
 - [Ruby](/ruby)
 - [SCSS](/scss)


### PR DESCRIPTION
I noticed that there is a README for Redis which recommends the best practice of not calling `redis.keys(*)`. This file is linked to from one of our other documentation pages but not the main global-style-guides README. So, I am adding a link to the Redis README from the main README.

