### PR TITLE
Remove mentions of console

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -287,14 +287,6 @@
     ```
   </details>
 
-- <a name="use-one-offs"></a>
-  When _changing data_ in production, don't use the console. Instead _create a rake task_ and submit it for review.
-  <sup>[link](#use-one-offs)</sup>
-
-- <a name="dont-use-console"></a>
-  When _reading data_ from production, avoid using the console, use redash instead.
-  <sup>[link](#dont-use-console)</sup>
-
 - <a name="service-object-method"></a>
   Service objects should have a single public method `#run`, which does not accept arguments
   <sup>[link](#service-object-method)</sup>


### PR DESCRIPTION
Successor to https://github.com/cookpad/global-style-guides/pull/118

Our new setup with trapdoor basically makes these points redundant, so should be able to remove now?

Related: https://github.com/cookpad/web-chapter/issues/94#issuecomment-533516852