### PR TITLE
Fix Style/NegatedIf cop

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -136,7 +136,8 @@ Style/ModuleFunction:
   Enabled: false
 
 Style/NegatedIf:
-  Enabled: both
+  Enabled: true
+  EnforcedStyle: both
 
 Style/NegatedWhile:
   Enabled: false


### PR DESCRIPTION
from `rubocop 0.75` `Style/NegatedIf` gives error saying

```
#!/bin/bash -eo pipefail
bundle exec rubocop 
Property Enabled of cop Style/NegatedIf is supposed to be a boolean and both is not.
Exited with code 1
```

I guess `rubocop 0.75` started checking `boolean` in `Enabled` statement strictly.

The correct cop is to write it `EnforcedStyle: both` according to
https://github.com/rubocop-hq/rubocop/blob/3c010bf517ff88c3e64ee49d056ad1d9e771356b/config/default.yml#L3102-L3111