### PR TITLE
Fix anchor links in BEM documentation

### DIFF
--- a/scss/bem/README.md
+++ b/scss/bem/README.md
@@ -6,8 +6,8 @@ Currently not all CSS have been converted to this style so it's a work in progre
 ## BEM
 
 BEM is a set of guidelines for naming classes which helps us produce maintainable CSS by:
-- Avoiding the infinite inheritance of CSS and providing the concept of closures by using unique CSS classes per element <sup>[1](useful-links-and-citations)</sup>
-- Reducing style conflicts by limiting the specificity of the CSS rules we create <sup>[1](useful-links-and-citations)</sup>
+- Avoiding the infinite inheritance of CSS and providing the concept of closures by using unique CSS classes per element <sup>[1](#useful-links-and-citations)</sup>
+- Reducing style conflicts by limiting the specificity of the CSS rules we create <sup>[1](#useful-links-and-citations)</sup>
 
 
 ```


### PR DESCRIPTION
Fixes the `[1]` links in the BEM readme.
You can check it works by looking at the [formatted document](https://github.com/cookpad/global-style-guides/blob/3999180cd80b598c5585d96728a69ec930384bed/scss/bem/README.md).