### PR TITLE
Add reference to 'Dealing with flaky tests' blog article

### DIFF
--- a/rspec/README.md
+++ b/rspec/README.md
@@ -487,4 +487,4 @@ These are some of the conventions we follow:
   </details>
 - <a name="#methodical-flaky-specs"></a>
   Be methodical towards flaky specs.
-  <sup>[link](#methodical-flaky-specs) [explanation](https://sourcediving.com/dealing-with-flaky-tests-d7c17227ab26)</sup>
+  <sup>[link](#methodical-flaky-specs) [explanation](https://medium.com/@davidstosik/a-methodological-approach-to-fixing-flaky-tests-92a39162b769?postPublishedType=repub)</sup>

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -485,3 +485,6 @@ These are some of the conventions we follow:
     end
     ```
   </details>
+- <a name="#methodical-flaky-specs"></a>
+  Be methodical towards flaky specs.
+  <sup>[link](#methodical-flaky-specs) [explanation](https://sourcediving.com/dealing-with-flaky-tests-d7c17227ab26)</sup>


### PR DESCRIPTION
In the same vein as @balvig's #149, after a few PR reviews that ended on the long side, and a few flaky specs I worked on myself, I wrote [dealing with flaky tests](https://sourcediving.com/dealing-with-flaky-tests-d7c17227ab26) to act as a reference I could refer to when dealing with a flaky spec myself, or reviewing a pull request for which it could be helpful.

I'll admit this is not really a style guide, but this is a methodology (good practice?) that I believe could help in many instances of trying to fix a flaky spec.

I'll be more than happy to discuss details of the article, or even amend it if anyone has valuable suggestions! 🙏 