### PR TITLE
Update configuration for RuboCop 0.77

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -164,7 +164,7 @@ Style/PerlBackrefs:
   Enabled: false
 
 Naming/PredicateName:
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
 
 Style/Proc:
@@ -248,7 +248,7 @@ Lint/DeprecatedClassMethods:
 Lint/ElseLayout:
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 Lint/LiteralInInterpolation:


### PR DESCRIPTION
The new version of RuboCop has some [breaking changes](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes).

When trying to run the new version, it fails with one exception due to configuration changes. 

```
Error: The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop-ruby.yml, please update it)
obsolete parameter NamePrefixBlacklist (for Naming/PredicateName) found in .rubocop-ruby.yml
`NamePrefixBlacklist` has been renamed to `ForbiddenPrefixes`.
```

Historically, new versions of Rubocop fail with old configurations, however old versions simply ignore the new settings with a warning.
So projects that still run the previous version of RuboCop will not fail, although they may stop performing some checks.

Example: Running this new configuration with the previous version:

```
Warning: unrecognized cop Lint/SuppressedException found in .rubocop-ruby.yml
Warning: Naming/PredicateName does not support ForbiddenPrefixes parameter.

Supported parameters are:

  - Enabled
  - NamePrefix
  - NamePrefixBlacklist
  - NameWhitelist
  - MethodDefinitionMacros
  - Exclude
```

