### PR TITLE
Add explanation to 'Dont add HTML to locale file'

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -261,8 +261,8 @@
 
 - <a name="dont-html-in-locale"></a>
   Don't include HTML in locale file
-  <sup>[link](#dont-html-in-locale)</sup>
-
+  <sup>[link](#dont-html-in-locale)
+  [explanation](https://github.com/cookpad/global-web/pull/15763#issuecomment-554836409)</sup>
   <details>
     <summary><em>Example</em></summary>
 


### PR DESCRIPTION
I still frequently see that we add `_html` keys to our locale files.  @davidstosik wrote a good How To in one of our recent translation PRs. 

I'm planning to summarise this in a blog article but as long as we don't have this, we should add a link to this comment so it does not get lost and add some more context.

https://github.com/cookpad/global-web/pull/15763#issuecomment-554836409