### PR TITLE
Rename Metrics/LineLength to Layout/LineLength

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -6,7 +6,7 @@ Metrics/BlockLength:
     - lib/tasks/**/*.rake
     - Gemfile
 
-Metrics/LineLength:
+Layout/LineLength:
   AllowHeredoc: true
   AllowURI: true
   Max: 120


### PR DESCRIPTION
This cope was renamed back in https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0780-2019-12-18.

This removed the warning:
```
.rubocop-https---raw-githubusercontent-com-cookpad-global-style-guides-master--rubocop-ruby-yml: Metrics/LineLength has the wrong namespace - should be Layout
```