### PR TITLE
Link to documentation on alternate naming schemes

### DIFF
--- a/scss/bem/README.md
+++ b/scss/bem/README.md
@@ -19,7 +19,7 @@ BEM is a set of guidelines for naming classes which helps us produce maintainabl
 - **Modifier:** Different states/exceptions
 
 We follow the recommendations of the [Official BEM Methodology](https://en.bem.info/methodology/quick-start) as our BEM style guide with one exception: 
-- Instead of `block__element_modifier` we use `block__element--modifier`
+- Instead of `block__element_modifier` we use [`block__element--modifier`](https://en.bem.info/methodology/naming-convention/#two-dashes-style)
 
 ### Example
 


### PR DESCRIPTION
Just noticed that this is now actually covered in the official BEM docs under https://en.bem.info/methodology/naming-convention/#alternative-naming-schemes.