### PR TITLE
Add preference on `click_on` into the style guide

### DIFF
--- a/rspec/README.md
+++ b/rspec/README.md
@@ -145,6 +145,10 @@ These are some of the conventions we follow:
 - <a name="prefer-have-text"></a>
   Prefer `have_text` over `have_content`
   <sup>[link](#prefer-have-text)</sup>
+  
+- <a name="prefer-click-on"></a>
+  Prefer `click_on` over `click_link` or `click_button`
+  <sup>[link](#prefer-click-on)</sup>
 
 - <a name="prefer-descriptive-dummy-data"></a>
   Prefer "descriptive" dummy data over realistic dummy data


### PR DESCRIPTION
As @balvig pointed me out multiple times during my task of migrating old specs, we now prefer `click_on` over a specific `click_link` or `click_button` in feature specs.

This PR is to make it an official preference into the style guide, <del>and hopefully we can write a cop to automatically check for this</del>.

/cc @cookpad/web-chapter 