### PR TITLE
Add enum best practice

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -380,3 +380,25 @@
   Leverage top-down development and feature toggles to keep pull requests small.
   <sup>[link](#leverage-top-down)
 [explanation](https://sourcediving.com/a-practical-guide-to-small-and-easy-to-review-pull-requests-a7f04a01d5d5)</sup>
+- <a name="enum"></a>
+  Use string to store enum state instead of integer.
+  <sup>[link](#enum)</sup>
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    # Bad
+    class AddColumnMigration < ActiveRecord::Migration[6.0]
+      def change
+        add_column :status, :table, :integer
+      end
+    end
+
+    # Good
+    class AddColumnMigration < ActiveRecord::Migration[6.0]
+      def change
+        add_column :status, :table, :string
+      end
+    end
+    ```
+  </details>


### PR DESCRIPTION
Triggered by the discussion in https://github.com/cookpad/global-web/pull/17851#discussion_r399356551, I was wondering what we prefer to use to store an enum field.
In our codebase, we currently use both integers and strings. I'm not suggesting that we should refactor however we decide but when we introduce a new enum we should follow the style guide.

## String
Using a string as enum in the database makes the data more descriptive without the codebase. Plain SQL queries will be more descriptive as they don't contain numbers but strings instead.

## Integers
We can potentially change easily the name of an enum state without the need of a migration as the integer value will stay the same.

