### PR TITLE
Correct variable name in example code

### DIFF
--- a/rspec/README.md
+++ b/rspec/README.md
@@ -502,14 +502,14 @@ These are some of the conventions we follow:
     ```ruby
     ## Bad
     it "does something" do
-      user = create(:recipe)
+      recipe = create(:recipe)
 
       expect(recipe.title).to eq("Recipe Title")
     end
 
     ## Good
     it "does something" do
-      user = create(:recipe, title: "Recipe Title")
+      recipe = create(:recipe, title: "Recipe Title")
 
       expect(recipe.title).to eq("Recipe Title")
     end


### PR DESCRIPTION
Not super important since this is example code, but just for consistency's sake I am changing the `user` variable to `recipe` so that `recipe.title` wouldn't raise an hypothetical exception...