### PR TITLE
Enable new pending rubocop cops

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -294,3 +294,24 @@ Style/PercentLiteralDelimiters:
 
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: required
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
This closes https://github.com/cookpad/global-style-guides/issues/163

These cops get introduced and are in pending status until next major release:

* Layout/SpaceAroundMethodCallOperator (0.82)
* Lint/RaiseException (0.81)
* Lint/StructNewOverride (0.81)
* Style/ExponentialNotation (0.82)
* Style/HashEachMethods (0.80)
* Style/HashTransformKeys (0.80)
* Style/HashTransformValues (0.80)