### PR TITLE
Expanded description of "don't abuse the zero key"

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -256,8 +256,19 @@
   <sup>[link](#scope-generic-phrases-under-common)</sup>
 
 - <a name="dont-abuse-zero-key"></a>
-  Don't use i18n `zero:` key to display a "no results" message (it is intended only to allow proper grammar)
+  Don't use i18n `zero:` key to display a "no results" message. 
   <sup>[link](#dont-abuse-zero-key)</sup>
+  <details>
+    <summary><em>Explanation</em></summary>
+  
+    <pre>  
+      Pluralization rules vary from language to language and keys are automatically added and 
+      removed from the translation files. So, the `zero:` key cannot be relied on to be present 
+      for every language. 
+      
+      Use a specific key for the "no results" message instead.
+    </pre>
+  </details>
 
 - <a name="dont-html-in-locale"></a>
   Don't include HTML in locale file

--- a/rails/README.md
+++ b/rails/README.md
@@ -256,7 +256,7 @@
   <sup>[link](#scope-generic-phrases-under-common)</sup>
 
 - <a name="dont-abuse-zero-key"></a>
-  Don't use i18n `zero:` key to display a "no results" message. 
+  Don't use i18n `zero:` key to display a "no results" message.
   <sup>[link](#dont-abuse-zero-key)</sup>
   <details>
     <summary><em>Example</em></summary>

--- a/rails/README.md
+++ b/rails/README.md
@@ -259,7 +259,7 @@
   Don't use i18n `zero:` key to display a "no results" message. 
   <sup>[link](#dont-abuse-zero-key)</sup>
   <details>
-    <summary><em>Explanation</em></summary>
+    <summary><em>Example</em></summary>
     
     ```yml
     # Pluralization rules vary from language to language and keys are automatically added and 

--- a/rails/README.md
+++ b/rails/README.md
@@ -260,14 +260,26 @@
   <sup>[link](#dont-abuse-zero-key)</sup>
   <details>
     <summary><em>Explanation</em></summary>
-  
-    <pre>  
-      Pluralization rules vary from language to language and keys are automatically added and 
-      removed from the translation files. So, the `zero:` key cannot be relied on to be present 
-      for every language. 
-      
-      Use a specific key for the "no results" message instead.
-    </pre>
+    
+    ```yml
+    # Pluralization rules vary from language to language and keys are automatically added and 
+    # removed from the translation files. So the `zero:` key cannot be relied on to be present 
+    # for every language. 
+    # 
+    # Use a separate key for the "no results" message instead.
+    #
+    # Bad
+    search_results:
+      zero: "There were no results"
+      one: "1 recipe found"
+      other: "%{count} recipes found"
+ 
+    # Good
+    search_results:
+      one: "1 recipe found"
+      other: "%{count} recipes found"
+    search_no_results: "There were no results"
+    ``` 
   </details>
 
 - <a name="dont-html-in-locale"></a>


### PR DESCRIPTION
I think the information about pluralization keys being configured to be automatically added and dropped by OneSky is useful for understanding the "don't abuse the zero key" rule.

Inspired by this discussion in Slack: https://ckpd.slack.com/archives/C06B9GD9D/p1589364941475900