### PR TITLE
Follow consistent ERB indent style

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -399,6 +399,42 @@
     ```
   </details>
 
+- <a name="consistent-erb-indent"></a>
+  Follow consistent ERB indent style
+  <sup>[link](#consistent-erb-indent)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```erb
+    <!-- Bad -->
+
+      <!-- ERB tag opener/closer on its own line -->
+
+        <%= render "accounts/header",
+              left_navigation: link_to(...),
+              dismissable: local_assigns[:dismissable]
+        %>
+
+        <%=
+          render "accounts/header",
+            left_navigation: link_to(...),
+            dismissable: local_assigns[:dismissable]
+        %>
+
+      <!-- Wrong indentation for lines after first inside ERB tag -->
+
+        <%= render "accounts/header",
+            left_navigation: link_to(...),
+            dismissable: local_assigns[:dismissable] %>
+
+    <!-- Good -->
+
+      <%= render "accounts/header",
+            left_navigation: link_to(...),
+            dismissable: local_assigns[:dismissable] %>
+    ```
+
 - <a name="leverage-top-down"></a>
   Leverage top-down development and feature toggles to keep pull requests small.
   <sup>[link](#leverage-top-down)

--- a/rails/README.md
+++ b/rails/README.md
@@ -409,13 +409,13 @@
     ```erb
     <!-- Bad -->
 
-      <!-- ERB tag opener/closer on its own line -->
+      <!-- ERB tag closer on its own line -->
       <%= render "accounts/header",
             left_navigation: link_to(...),
             dismissable: true
       %>
 
-      <!-- Another example of ERB tag opener/closer on its own line -->
+      <!-- Another example of ERB tag opener & closer on their own line -->
       <%=
         render "accounts/header",
           left_navigation: link_to(...),

--- a/rails/README.md
+++ b/rails/README.md
@@ -410,23 +410,22 @@
     <!-- Bad -->
 
       <!-- ERB tag opener/closer on its own line -->
-
-        <%= render "accounts/header",
-              left_navigation: link_to(...),
-              dismissable: true
-        %>
-
-        <%=
-          render "accounts/header",
+      <%= render "accounts/header",
             left_navigation: link_to(...),
             dismissable: true
-        %>
+      %>
+
+      <!-- Another example of ERB tag opener/closer on its own line -->
+      <%=
+        render "accounts/header",
+          left_navigation: link_to(...),
+          dismissable: true
+      %>
 
       <!-- Wrong indentation for lines after first inside ERB tag -->
-
-        <%= render "accounts/header",
-            left_navigation: link_to(...),
-            dismissable: true %>
+      <%= render "accounts/header",
+          left_navigation: link_to(...),
+          dismissable: true %>
 
     <!-- Good -->
 

--- a/rails/README.md
+++ b/rails/README.md
@@ -415,7 +415,7 @@
             dismissable: true
       %>
 
-      <!-- Another example of ERB tag opener & closer on their own line -->
+      <!-- ERB tag opener & closer on their own line -->
       <%=
         render "accounts/header",
           left_navigation: link_to(...),

--- a/rails/README.md
+++ b/rails/README.md
@@ -413,26 +413,26 @@
 
         <%= render "accounts/header",
               left_navigation: link_to(...),
-              dismissable: local_assigns[:dismissable]
+              dismissable: true
         %>
 
         <%=
           render "accounts/header",
             left_navigation: link_to(...),
-            dismissable: local_assigns[:dismissable]
+            dismissable: true
         %>
 
       <!-- Wrong indentation for lines after first inside ERB tag -->
 
         <%= render "accounts/header",
             left_navigation: link_to(...),
-            dismissable: local_assigns[:dismissable] %>
+            dismissable: true %>
 
     <!-- Good -->
 
       <%= render "accounts/header",
             left_navigation: link_to(...),
-            dismissable: local_assigns[:dismissable] %>
+            dismissable: true %>
     ```
 
 - <a name="leverage-top-down"></a>

--- a/rails/README.md
+++ b/rails/README.md
@@ -260,12 +260,12 @@
   <sup>[link](#dont-abuse-zero-key)</sup>
   <details>
     <summary><em>Example</em></summary>
-    
+
     ```yml
-    # Pluralization rules vary from language to language and keys are automatically added and 
-    # removed from the translation files. So the `zero:` key cannot be relied on to be present 
-    # for every language. 
-    # 
+    # Pluralization rules vary from language to language and keys are automatically added and
+    # removed from the translation files. So the `zero:` key cannot be relied on to be present
+    # for every language.
+    #
     # Use a separate key for the "no results" message instead.
     #
     # Bad
@@ -273,13 +273,13 @@
       zero: "There were no results"
       one: "1 recipe found"
       other: "%{count} recipes found"
- 
+
     # Good
     search_results:
       one: "1 recipe found"
       other: "%{count} recipes found"
     search_no_results: "There were no results"
-    ``` 
+    ```
   </details>
 
 - <a name="dont-html-in-locale"></a>
@@ -407,31 +407,28 @@
     <summary><em>Example</em></summary>
 
     ```erb
-    <!-- Bad -->
-
-      <!-- ERB tag closer on its own line -->
-      <%= render "accounts/header",
-            left_navigation: link_to(...),
-            dismissable: true
-      %>
-
-      <!-- ERB tag opener & closer on their own line -->
-      <%=
-        render "accounts/header",
+    <!-- Bad: ERB tag closer on its own line -->
+    <%= render "accounts/header",
           left_navigation: link_to(...),
           dismissable: true
-      %>
+    %>
 
-      <!-- Wrong indentation for lines after first inside ERB tag -->
-      <%= render "accounts/header",
-          left_navigation: link_to(...),
-          dismissable: true %>
+    <!-- Bad: ERB tag opener & closer on their own line -->
+    <%=
+      render "accounts/header",
+        left_navigation: link_to(...),
+        dismissable: true
+    %>
+
+    <!-- Bad: Wrong indentation for lines after first inside ERB tag -->
+    <%= render "accounts/header",
+        left_navigation: link_to(...),
+        dismissable: true %>
 
     <!-- Good -->
-
-      <%= render "accounts/header",
-            left_navigation: link_to(...),
-            dismissable: true %>
+    <%= render "accounts/header",
+      left_navigation: link_to(...),
+      dismissable: true %>
     ```
 
 - <a name="leverage-top-down"></a>


### PR DESCRIPTION
In addition to [setting up ERB-lint](https://github.com/cookpad/global-web/pull/20354), these rules will need to be looked after manually, for now.

![image](https://user-images.githubusercontent.com/816901/91006403-3e77e280-e614-11ea-8fe5-f5ffc04144e7.png)
