### PR TITLE
Update Kafka styleguide with message consistency guidelines

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -17,6 +17,14 @@
     "title": "edited title"
   }
 }
+{
+  "type": "registered_user_event",
+  "key": "users_123",
+  "body": {
+    "title": "registered title"
+    "description": "registered description"
+  }
+}
 
 // Good
 {

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -14,7 +14,7 @@
   "type": "registered_user_event",
   "key": "users_123",
   "body": {
-    "title": "registered title"
+    "title": "registered title",
     "description": "registered description"
   }
 }
@@ -29,6 +29,14 @@
 
 
 // Good
+{
+  "type": "registered_user_event",
+  "key": "users_123",
+  "body": {
+    "title": "registered title",
+    "description": "registered description"
+  }
+}
 {
   "type": "edited_user_event",
   "key": "users_123",

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -5,6 +5,30 @@
 - <a name="keep-small-messages"></a>
   Keep messages as small as possible. Expose just enough data so messages make sense to other systems. Use simple RESTish payloads. <sup>[link](#keep-small-messages)</sup> <sup>[explanation](https://martinfowler.com/articles/microservices.html#SmartEndpointsAndDumbPipes)</sup>
 
+- <a name="message-consistency"></a>
+  Keep messages payloads consistant between messages that share the same key format, if the topic is configured to be compacted. <sup>[link](#message-consistency)</sup>
+
+```json
+// Bad
+{
+  "type": "edited_user_event",
+  "key": "users_123",
+  "body": {
+    "title": "edited title"
+  }
+}
+
+// Good
+{
+  "type": "edited_user_event",
+  "key": "users_123",
+  "body": {
+    "title": "edited title",
+    "description": "previous description"
+  }
+}
+```
+
 - <a name="events-name-past-tense"></a>
   Prefer `{PastTenseVerb}_{Entity}`format for naming the events, event names should be in past tense. <sup>[link](#real-world-events) [explanation](https://youtu.be/JzWJI8kW2kc?t=707)</sup>
 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -8,6 +8,8 @@
 - <a name="message-consistency"></a>
   Keep message payloads consistent between messages that share the same key format, if the topic is configured to be compacted, and if consumers expect to replay the compacted events and get a full picture of a resource's current state. <sup>[link](#message-consistency)</sup>
 
+<details>
+  <summary><em>Example</em></summary>
 ```json
 // Bad
 {

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -48,7 +48,7 @@
   }
 }
 ```
-
+</details>
 - <a name="events-name-past-tense"></a>
   Prefer `{PastTenseVerb}_{Entity}`format for naming the events, event names should be in past tense. <sup>[link](#real-world-events) [explanation](https://youtu.be/JzWJI8kW2kc?t=707)</sup>
 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -11,13 +11,6 @@
 ```json
 // Bad
 {
-  "type": "edited_user_event",
-  "key": "users_123",
-  "body": {
-    "title": "edited title"
-  }
-}
-{
   "type": "registered_user_event",
   "key": "users_123",
   "body": {
@@ -26,13 +19,22 @@
   }
 }
 
+{
+  "type": "edited_user_event",
+  "key": "users_123",
+  "body": {
+    "title": "edited title"
+  }
+}
+
+
 // Good
 {
   "type": "edited_user_event",
   "key": "users_123",
   "body": {
     "title": "edited title",
-    "description": "previous description"
+    "description": "registered description"
   }
 }
 ```

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -11,7 +11,7 @@
 <details>
   <summary><em>Example</em></summary>
 ```json
-// Bad
+// Bad (notice missing description key in second message)
 {
   "type": "registered_user_event",
   "key": "users_123",

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -6,7 +6,7 @@
   Keep messages as small as possible. Expose just enough data so messages make sense to other systems. Use simple RESTish payloads. <sup>[link](#keep-small-messages)</sup> <sup>[explanation](https://martinfowler.com/articles/microservices.html#SmartEndpointsAndDumbPipes)</sup>
 
 - <a name="message-consistency"></a>
-  Keep messages payloads consistant between messages that share the same key format, if the topic is configured to be compacted. <sup>[link](#message-consistency)</sup>
+  Keep message payloads consistent between messages that share the same key format, if the topic is configured to be compacted, and if consumers expect to replay the compacted events and get a full picture of a resource's current state. <sup>[link](#message-consistency)</sup>
 
 ```json
 // Bad

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -39,6 +39,7 @@
     "description": "registered description"
   }
 }
+
 {
   "type": "edited_user_event",
   "key": "users_123",

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -10,6 +10,7 @@
 
 <details>
   <summary><em>Example</em></summary>
+
 ```json
 // Bad (notice missing description key in second message)
 {
@@ -28,7 +29,6 @@
     "title": "edited title"
   }
 }
-
 
 // Good
 {
@@ -49,7 +49,9 @@
   }
 }
 ```
+
 </details>
+
 - <a name="events-name-past-tense"></a>
   Prefer `{PastTenseVerb}_{Entity}`format for naming the events, event names should be in past tense. <sup>[link](#real-world-events) [explanation](https://youtu.be/JzWJI8kW2kc?t=707)</sup>
 


### PR DESCRIPTION
Trying to capture some of the discussion that has recently taken place in https://github.com/cookpad/platform-team/issues/10#issuecomment-716637676 into a simple to understand style guide recommendation.

We have realised that the existing guidelines about [keeping messages small](https://github.com/cookpad/global-style-guides/tree/master/kafka#keep-small-messages) needs some clarifications when the topic the messages are being emitted onto is configured with compaction enabled.
