### PR TITLE
 Add guideline to use prettier to format css

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -1,3 +1,5 @@
 # CSS
 
 Cookpad uses [TailwindCSS](https://tailwindcss.com/) for styling and [BEM](https://en.bem.info/methodology/quick-start/) for naming components.
+
+Cookpad uses [Prettier](https://prettier.io) to format CSS.


### PR DESCRIPTION
## What
Update the styleguides to reflect that we use Prettier to format CSS.

## Why
To avoid [surprising developers](https://github.com/cookpad/global-style-guides/pull/176#issuecomment-764734398) when inconsistent CSS is flagged. In addition to the reasons we [documentated](https://github.com/cookpad/global-style-guides/pull/176#issue-551016396) our usage of Pretteir for JS code.

> Our style guides should be kept up to date with current our practices, to better help onboard new starters and provide context for discussions.