### PR TITLE
Enforce a single indent for multi-line arguments

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -273,6 +273,9 @@ Lint/UselessAssignment:
   Exclude:
     - spec/**/*
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/EmptyLines:
   Exclude:
     - spec/**/*


### PR DESCRIPTION
# What

This PR adjusts the format enforced by Rubocop when passing arguments to a method over multiple lines.

The Rubocop cop is named [`Layout/ArgumentAlignment`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ArgumentAlignment). By default, it expects following arguments to be vertically aligned with the first:

## Before

```rb
# Good

foo :bar,
    :baz

foo(
  :bar,
  :baz
)

# Bad

foo :bar,
  :baz

foo(
  :bar,
    :baz
)
```

## After

By using the option `EnforcedStyle: with_fixed_indentation`, Rubocop enforces all arguments to be indented only once, relatively to the method call they belong to:

```rb
# Still good
foo(
  :bar,
  :baz
)

# Now good
foo :bar,
  :baz

# Now bad
foo :bar,
    :baz
```

# Why

The original setup encouraged excessive indentation when the method name becomes longer:

```rb
do_something :arg1,
             :arg2
#^^^^^^^^^^^^ too many spaces!
```

This also puts Rubocop in line with our [consistent ERB indent](https://github.com/cookpad/global-style-guides/tree/master/rails#consistent-erb-indent) rule:

```erb
<!-- Good -->
<%= render "accounts/header",
  left_navigation: link_to(...),
  dismissable: true %>

<!-- Which makes this bad too -->
<%= render "accounts/header",
           left_navigation: link_to(...),
           dismissable: true %>
```

# Anything else?

This was triggered by a conversation ([starting here on Slack](https://ckpd.slack.com/archives/C06B9GD9D/p1613440311359600)) I had with @balvig regarding the application of Rubocop's `Layout/ArgumentAlignment` to ERB files thanks to ERB-linter ([setup PR still in review](https://github.com/cookpad/global-web/pull/20354)).

This change introduces 164 offenses in the global-web codebase, luckily they are auto-correctable, so I could easily open a PR that fixes the offenses. (There is only one offense to the prior rule.)

<details><summary>Here is a list of those offenses.</summary>

```
app/controllers/admin/activities/comment_dismissals_controller.rb:12:25: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                        notice: t("admin.common.notice.updated")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/activities/comment_dismissals_controller.rb:26:25: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                        notice: t("admin.common.notice.updated")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/activities/messages/base_controller.rb:30:29: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                            notice: t("admin.moderation.messages.create.success")
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/activities/recipes_controller.rb:37:27: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                          notice: t("admin.recipes.update.updated")
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/activities/roles_controller.rb:15:27: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                          notice: t("admin.common.notice.updated")
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/global_feeds/seasonal_events_controller.rb:73:20: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                   :recipe_1_id, :recipe_2_id, :recipe_3_id, :recipe_4_id, :recipe_5_id, :recipe_6_id, :recipe_7_id)
                   ^^^^^^^^^^^^
app/controllers/admin/moderation/guides/recipes_controller.rb:15:25: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                        notice: t("admin.guides.common.no_recipes_to_be_guided")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/moderation/reservations/assignments_controller.rb:18:29: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                            notice: t("admin.moderation.reservation.assignments.success")
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/moderation/reviews/recipes_controller.rb:13:25: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                        notice: t("admin.reviews.common.no_recipes_to_be_reviewed")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/moderation/reviews/reported_chats_controller.rb:13:25: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                        notice: "no reported chats to review"
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/retention_email_nominations_controller.rb:24:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    notice: t("admin.retention_email_nominations.notice.nominations_cleared")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/review/assignments_controller.rb:11:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                count: moderateable_ids.count, ...
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/roles_controller.rb:68:23: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                      alert: t("admin.users.update.role.message", user_name: user.name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/search_categories_controller.rb:44:18: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                 keywords_attributes: keywords_attributes.push(:displayed_recipe_url, ...
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/admin/search_categories_controller.rb:45:64: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                                               subkeywords_attributes: keywords_attributes))
                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/challenge_entries_controller.rb:29:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    notice: I18n.t("challenges.entries.create.success", challenge: challenge.name)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/challenge_entries_controller.rb:32:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    alert: entry.errors.full_messages.to_sentence
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/concerns/api/paginatable.rb:28:34: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                 page: params[:page], ...
                                 ^^^^^^^^^^^^^^^^^^^^
app/events/searches/searched_recipe_event.rb:23:19: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                  :source
                  ^^^^^^^
app/helpers/admin/users_helper.rb:18:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              class: "signal signal--#{PREMIUM_PAYMENT_METHOD_STATUS_SIGNALS[payment_method.status.to_sym]}", ...
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/inputs/region_picker_input.rb:6:40: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                       :last, :first, value_method, :country_name_with_flag,
                                       ^^^^^
app/inputs/region_picker_input.rb:7:40: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                       input_options, merged_input_options)
                                       ^^^^^^^^^^^^^
app/inputs/reviewer_picker_input.rb:6:40: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                       :last, :first, :id, :name,
                                       ^^^^^
app/inputs/reviewer_picker_input.rb:7:40: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                       input_options, merged_input_options)
                                       ^^^^^^^^^^^^^
app/mailers/concerns/sparkpost_delivery_method.rb:8:25: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                        address:              "smtp.sparkpostmail.com", ...
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/mailers/retention_mailer.rb:54:29: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                            placeholders_with_aliases(template_placeholders.merge(recipient_name: recipient.name)))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/broadcast.rb:12:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             -> { unscope(where: :parent_id) },
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/broadcast.rb:13:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             class_name: "Moderation::Message", ...
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/moderation/message.rb:5:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               class_name: "Admin::Moderation::MessageReply", ...
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/moderation/message_batch.rb:20:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               class_name: "Admin::Moderation::Message", ...
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/moderation/message_reply.rb:5:18: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                 class_name: "Moderation::Message", ...
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/moderation/misspelling.rb:8:17: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                uniqueness: { scope: :provider_id, case_sensitive: true }, ...
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/preview.rb:33:36: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                   placeholders: unknown_placeholders_with_corrections.to_sentence, ...
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/user.rb:22:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             foreign_key: :moderateable_id, ...
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/user.rb:26:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             -> { where(moderateable_type: "User").part_of_broadcast_or_batch.recently_sent },
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/admin/user.rb:27:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             foreign_key: :moderateable_id, ...
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:36:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :under_review?,
               ^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:37:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :need_guidance?,
               ^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:38:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :under_guidance?,
               ^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:39:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :reviewed?,
               ^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:40:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :reviewer,
               ^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:41:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :guide,
               ^^^^^^
app/models/concerns/moderation/moderateable.rb:42:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :flagged_with?,
               ^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:43:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :has_flag?,
               ^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:44:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :mark_as_reviewed,
               ^^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:45:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :trusted?,
               ^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:46:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :mark_as_trusted,
               ^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:47:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :book_review!,
               ^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:48:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :remove_reviewer,
               ^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:49:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :halt_moderation,
               ^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:50:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               to: :moderation_reservation, ...
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:54:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :remove_guidance,
               ^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:55:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :update_flag!,
               ^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:56:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :review_or_guide_again,
               ^^^^^^^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:57:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :awaiting_review?,
               ^^^^^^^^^^^^^^^^^
app/models/concerns/moderation/moderateable.rb:58:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               to: :start_moderation
               ^^^^^^^^^^^^^^^^^^^^^
app/models/concerns/reactable.rb:7:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             -> { where(user: Current.user) },
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/concerns/reactable.rb:8:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             as: :reactable, ...
             ^^^^^^^^^^^^^^^
app/models/country.rb:42:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           country_name: name, ...
           ^^^^^^^^^^^^^^^^^^^
app/models/firebase_dynamic_link.rb:49:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :amv,
                                ^^^^
app/models/firebase_dynamic_link.rb:50:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :utm_source,
                                ^^^^^^^^^^^
app/models/firebase_dynamic_link.rb:51:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :utm_medium,
                                ^^^^^^^^^^^
app/models/firebase_dynamic_link.rb:52:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :utm_content,
                                ^^^^^^^^^^^^
app/models/firebase_dynamic_link.rb:53:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :utm_campaign,
                                ^^^^^^^^^^^^^
app/models/firebase_dynamic_link.rb:54:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :efr,
                                ^^^^
app/models/firebase_dynamic_link.rb:55:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :pt,
                                ^^^
app/models/firebase_dynamic_link.rb:56:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :ct,
                                ^^^
app/models/firebase_dynamic_link.rb:57:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                :mt)
                                ^^^
app/models/global_feeds/base_feed.rb:31:19: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                  :query_params
                  ^^^^^^^^^^^^^
app/models/moderation/evaluation/comment_rate_limit_evaluation.rb:8:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               ordinal: num_recently_created_moderateables.ordinalize)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/moderation/evaluation/trustlist_evaluation.rb:40:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                user_name: user.name, reviewer_name: entry_reviewer.name)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/moderation/evaluation/update_evaluation.rb:37:18: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                 resource: resource.class.name.demodulize, attributes: updated_attributes.join("\n"))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/moderation/note.rb:12:13: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
            class_name: "Admin::InternalNote", ...
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/recipe.rb:82:13: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
            numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1, allow_nil: true }
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/search/recipe_search_log.rb:23:19: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                  :recommended_collection_item_track_param
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/search_category_keyword.rb:3:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             class_name: "SearchCategory", ...
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/search_category_keyword.rb:9:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             class_name: "Recipe", ...
             ^^^^^^^^^^^^^^^^^^^^^
app/models/search_category_keyword.rb:15:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           class_name: "SearchCategoryKeyword", ...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/search_category_keyword.rb:35:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                allow_destroy: true, ...
                                ^^^^^^^^^^^^^^^^^^^^
app/models/search_meta_tags.rb:3:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           :canonical_tag,
           ^^^^^^^^^^^^^^
app/models/search_meta_tags.rb:4:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           :alternate_hreflang_tags,
           ^^^^^^^^^^^^^^^^^^^^^^^^
app/models/search_meta_tags.rb:5:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           :search_canonical_url_params,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/search_meta_tags.rb:6:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           :search_url_params,
           ^^^^^^^^^^^^^^^^^^
app/models/search_meta_tags.rb:7:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           to: :view_context
           ^^^^^^^^^^^^^^^^^
app/models/share_images/recipe.rb:15:23: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                      length: relative_length(60)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/share_images/tip.rb:15:23: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                      length: relative_length(60)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/user.rb:35:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           class_name: "Follow", ...
           ^^^^^^^^^^^^^^^^^^^^^
app/models/user.rb:40:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           class_name: "Follow", ...
           ^^^^^^^^^^^^^^^^^^^^^
app/models/user.rb:46:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           through: :incoming_follows, ...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/user.rb:50:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           through: :outgoing_follows, ...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/user.rb:74:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           foreign_key: :moderateable_id, ...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/serializers/comment_without_replies_serializer.rb:5:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             :label, :liker_ids, :likes_count, :parent_user_name,
             ^^^^^^
app/serializers/comment_without_replies_serializer.rb:6:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             :replies_count, :status, :total_replies_count
             ^^^^^^^^^^^^^^
app/serializers/contest_serializer.rb:3:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             :rules, :state, :opened_at, :closed_at, :hashtag,
             ^^^^^^
app/serializers/contest_serializer.rb:4:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             :web_view_url, :entries_count, :user_entry_status
             ^^^^^^^^^^^^^
app/serializers/events/tip_serializer.rb:4:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               :language
               ^^^^^^^^^
app/serializers/recipe_serializer.rb:4:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             :edited_at, :bookmarks_count, :view_count, :feedbacks_count, :latitude, :longitude,
             ^^^^^^^^^^
app/serializers/recipe_serializer.rb:5:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             :image_vertical_offset, :image_horizontal_offset, :reaction_counts, :cooksnaps_count
             ^^^^^^^^^^^^^^^^^^^^^^
app/serializers/user_serializer.rb:3:14: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
             :follower_count, :followee_count, :href, :staff, :draft_recipes_count
             ^^^^^^^^^^^^^^^
app/services/payment/google_iab/log_subscription_service.rb:19:18: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                 :payment_free_trial?, to: :subscription
                 ^^^^^^^^^^^^^^^^^^^^
app/services/signup_service.rb:31:17: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                :phone_number_verification_code
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/views/suggestions/index.json.jbuilder:8:38: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                     keyword: suggestion, ...
                                     ^^^^^^^^^^^^^^^^^^^^
bin/ci-stats:17:10: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
         type: :string, ...
         ^^^^^^^^^^^^^^
bin/ci-stats:22:10: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
         type: :numeric, ...
         ^^^^^^^^^^^^^^^
bin/ci-stats:27:10: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
         type: :string, ...
         ^^^^^^^^^^^^^^
bin/rspec:16:44: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                           Pathname.new(__FILE__).realpath)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
config/initializers/feature_toggles.rb:684:16: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
               evaluate_on: "2020-06-30", ...
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
config/initializers/omniauth.rb:5:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           scope: "email,user_friends", ...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
config/initializers/omniauth.rb:14:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           scope: "email,profile", ...
           ^^^^^^^^^^^^^^^^^^^^^^^
config/initializers/omniauth.rb:19:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           public_key: secrets.oauth_odnoklassniki_public_key, ...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
config/initializers/omniauth.rb:23:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           scope: "friends,email", ...
           ^^^^^^^^^^^^^^^^^^^^^^^
config/initializers/omniauth.rb:27:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           scope: "name email", ...
           ^^^^^^^^^^^^^^^^^^^^
config/routes.rb:10:9: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
        to: "external_accounts#create", ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
config/routes.rb:13:11: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
          to: "sessions/oauths#create", ...
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/database_tools/recreate_options.rb:99:19: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                  <<~LOCALHELP.squish, String) { |dump_file| self.dump_file = dump_file }
                  ^^^^^^^^^^^^^^^^^^^
lib/database_tools/recreate_options.rb:113:19: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                  <<~DATABASEHELP, String) { |database| self.database = database }
                  ^^^^^^^^^^^^^^^
rubocop.rb:2:9: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
        root_path,
        ^^^^^^^^^
rubocop.rb:3:9: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
        class: "something"
        ^^^^^^^^^^^^^^^^^^
spec/features/admin_corrects_recipe_misspelling_spec.rb:27:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    title: "Misspelled english word", ...
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/admin_edits_recipe_section_headings_spec.rb:6:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    :reviewed,
                    ^^^^^^^^^
spec/features/admin_edits_recipe_section_headings_spec.rb:7:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    ingredients: [ ...
                    ^^^^^^^^^^^^^^
spec/features/admin_edits_recipe_section_headings_spec.rb:30:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    :reviewed,
                    ^^^^^^^^^
spec/features/admin_edits_recipe_section_headings_spec.rb:31:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    ingredients: [build(:ingredient, name: "ingredient headline", headline: false)])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/admin_edits_recipe_section_headings_spec.rb:48:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    :reviewed,
                    ^^^^^^^^^
spec/features/admin_edits_recipe_section_headings_spec.rb:49:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    ingredients: [build(:ingredient, name: "ingredient name", headline: true)])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/admin_reassigns_guides_spec.rb:50:31: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                              :reviewed, reviewer: former_staff, guide: former_staff)
                              ^^^^^^^^^
spec/features/admin_reviews_ingredients_spec.rb:7:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    ingredients: [ ...
                    ^^^^^^^^^^^^^^
spec/features/admin_reviews_recipes_spec.rb:342:21: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                    ingredients: [ ...
                    ^^^^^^^^^^^^^^
spec/features/admin_sends_moderation_messages_spec.rb:7:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           name: "Template Name", ...
           ^^^^^^^^^^^^^^^^^^^^^^
spec/features/admin_sends_moderation_messages_spec.rb:35:12: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
           name: "Encoded Template", ...
           ^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/admin_views_recipe_spec.rb:14:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                country_name: recipe.region.country_name, ...
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/admin_views_user_segmentations_spec.rb:48:45: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                            "Third segmentation",
                                            ^^^^^^^^^^^^^^^^^^^^
spec/features/admin_views_user_segmentations_spec.rb:49:45: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                            "Second segmentation")
                                            ^^^^^^^^^^^^^^^^^^^^^
spec/features/user_replies_to_recipe_comment_spec.rb:94:45: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                            "Older reply",
                                            ^^^^^^^^^^^^^
spec/features/user_replies_to_recipe_comment_spec.rb:95:45: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                            "More recent reply",
                                            ^^^^^^^^^^^^^^^^^^^
spec/features/user_replies_to_recipe_comment_spec.rb:96:45: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                            "More recent root comment")
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/user_views_homepage_spec.rb:151:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                link: t("home.duplicate_account.action"), ...
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/user_views_homepage_spec.rb:165:33: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                link: t("home.duplicate_account.action"), ...
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/user_views_homepage_spec.rb:177:37: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                    link: t("home.duplicate_account.action"), ...
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/mailers/retention_mailer_spec.rb:7:29: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                            type: "ask_publish_recipe", ...
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/mailers/retention_mailer_spec.rb:78:29: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                            type: "ask_publish_recipe", ...
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/moderation/evaluation/language_evaluation_spec.rb:13:24: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                       moderateable_type_name: "Recipe", provider: "cookpad-indonesia", detected_language: "English"))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/moderation/evaluation/language_evaluation_spec.rb:25:24: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                       moderateable_type_name: "Tip", provider: "cookpad-indonesia", detected_language: "English"))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/moderation/evaluation/language_evaluation_spec.rb:130:24: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                       provider: "cookpad-us", detected_language: "Swahili"))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/moderation/evaluation/trustlist_evaluation_spec.rb:21:18: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                 user_name: entry.user.name, reviewer_name: entry.reviewer.name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/moderation/evaluation/trustlist_evaluation_spec.rb:96:18: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                 user_name: entry.user.name, reviewer_name: entry.reviewer.name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/recipe_spec.rb:285:23: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                      ingredients: [build(:ingredient), Ingredient.new], ...
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/accounts_spec.rb:8:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              "User's permission on accepting marketing notifications",
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/accounts_spec.rb:9:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              scope: :user
              ^^^^^^^^^^^^
spec/requests/api/me/recipes/achievements_spec.rb:6:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              "Number of days to be considered while loading period statistics",
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/me/recipes/achievements_spec.rb:7:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              scope: :number_of_days, ...
              ^^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/me/recipes/achievements_spec.rb:10:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              "Number of days to be considered while calculating the total views per day",
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/me/recipes/achievements_spec.rb:11:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              scope: :number_of_days, ...
              ^^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/recipes_spec.rb:8:23: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                      title: "Recipe Title", ...
                      ^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/seasonal_ingredients_spec.rb:24:36: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                                   name: "Ingredient name", ...
                                   ^^^^^^^^^^^^^^^^^^^^^^^^
spec/requests/api/v21/chats/visibles_spec.rb:6:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              "number of memberships to display per page (default per_page is 20). Incompatible with cursor / limit."
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/admin/duplicate_contest_service_spec.rb:7:24: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                       description: "The Description", ...
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/admin/duplicate_contest_service_spec.rb:68:24: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                       awards: [build(:award, :with_image, name: "Contest award", description: "Award description")])
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/moderate_updated_recipe_service_spec.rb:51:20: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                   resource: "Recipe", attributes: '- title: "Recipe Title" -> "New Recipe Title"'))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/moderate_updated_recipe_service_spec.rb:185:20: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                   resource: "Recipe", attributes: '- title: "Recipe Title" -> "New Recipe Title"'))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/moderate_updated_tip_service_spec.rb:50:20: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                   resource: "Tip", attributes: '- title: "Tip Title" -> "New Tip Title"'))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/recipe_publication_service_spec.rb:102:17: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                user_name: trustlist_entry.user.name, reviewer_name: trustlist_entry.reviewer.name))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/tip_publication_service_spec.rb:67:20: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
                   provider: "cookpad-indonesia", detected_language: "English"))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/services/tip_publication_service_spec.rb:81:15: C: Layout/ArgumentAlignment: Use one level of indentation for arguments following the first line of a multi-line method call.
              user_name: trustlist_entry.user.name, reviewer_name: trustlist_entry.reviewer.name))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

3136 files inspected, 164 offenses detected, 164 offenses auto-correctable
```

</details>