### PR TITLE
Enable new cops until defined otherwise

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,6 @@ inherit_from:
   - .rubocop.ruby.yml
   - .rubocop.rails.yml
   - .rubocop.performance.yml
+
+AllCops:
+  NewCops: enable


### PR DESCRIPTION
# What

New cops introduced in new versions of Rubocop without configuration will be enabled by default.

# Why

Running Rubocop locally today triggers the following warnings:

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that can also opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Layout/BeginEndAlignment: # (new in 0.91)
  Enabled: true
Layout/EmptyLinesAroundAttributeAccessor: # (new in 0.83)
  Enabled: true
Lint/BinaryOperatorWithIdenticalOperands: # (new in 0.89)
  Enabled: true
Lint/ConstantDefinitionInBlock: # (new in 0.91)
  Enabled: true
Lint/DeprecatedOpenSSLConstant: # (new in 0.84)
  Enabled: true
...
```

This requires us to update our Rubocop config files every time a new version of Rubocop is introduced (see #164).

I'm taking the default approach that new cops exist because they provide value and are beneficial for the codebase. Rather than excluding new cops until someone learns about them and decides to enable them, I think that giving them a chance (and disabling those that annoy us) will provide more benefits.

# Anything else?

This addition might mean that we can remove the lines that were added by the PR I mentioned above.