### PR TITLE
Remove redundant 'Enabled: true' lines from Rubocop config

### DIFF
--- a/.rubocop.rails.yml
+++ b/.rubocop.rails.yml
@@ -1,8 +1,5 @@
 require: rubocop-rails
 
-Rails:
-  Enabled: true
-
 Rails/ActionFilter:
   Enabled: false
 
@@ -10,7 +7,6 @@ Rails/Delegate:
   Enabled: false
 
 Rails/Output:
-  Enabled: true
   Include:
     - app/**/*.rb
     - config/**/*.rb

--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -136,7 +136,6 @@ Style/ModuleFunction:
   Enabled: false
 
 Style/NegatedIf:
-  Enabled: true
   EnforcedStyle: both
 
 Style/NegatedWhile:
@@ -195,15 +194,12 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/TrailingCommaInArrayLiteral:
-  Enabled: true
   EnforcedStyleForMultiline: no_comma
 
 Style/TrailingCommaInHashLiteral:
-  Enabled: true
   EnforcedStyleForMultiline: no_comma
 
 Style/TrailingCommaInArguments:
-  Enabled: true
   EnforcedStyleForMultiline: no_comma
 
 Style/FormatStringToken:
@@ -266,9 +262,6 @@ Lint/RequireParentheses:
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
-Lint/Void:
-  Enabled: true
-
 Lint/UselessAssignment:
   Exclude:
     - spec/**/*
@@ -297,24 +290,3 @@ Style/PercentLiteralDelimiters:
 
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: required
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true


### PR DESCRIPTION
# What

This cleans up a few redundant `Enabled: true` lines from all our Rubocop configs.

# Why

A cop provided by Rubocop is enabled by default. It is not necessary to specify that in our configuration file.
The exception to the rule above is "pending" cops, which have been released in recent versions of Rubocop but that the developer did not want to enable by default without warning. If Rubocop runs with cops marked as "pending", it will display the warning message that I have described in #180.

As we now enable new cops by default (until we decide to disable them on a case-by-case), the warning does not show anymore, and it is not necessary to explicitly enable all of them.

# Anything else?

Here's a quick before-after.

<details><summary>This is the difference of output for <code>rubocop --show-cops</code>.</summary>

```diff
--- before.txt	2021-02-17 15:41:23.000000000 +0900
+++ after.txt	2021-02-17 15:57:26.000000000 +0900
@@ -818,7 +818,7 @@
 # Supports --auto-correct
 Layout/SpaceAroundMethodCallOperator:
   Description: Checks method call operators to not have spaces around them.
-  Enabled: true
+  Enabled: pending
   VersionAdded: '0.82'
 
 # Supports --auto-correct
@@ -1396,7 +1396,7 @@
   Description: Checks for `raise` or `fail` statements which are raising `Exception`
     class.
   StyleGuide: "#raise-exception"
-  Enabled: true
+  Enabled: pending
   Safe: false
   VersionAdded: '0.81'
   VersionChanged: '0.86'
@@ -1571,7 +1571,7 @@
 
 Lint/StructNewOverride:
   Description: Disallow overriding the `Struct` built-in methods via `Struct.new`.
-  Enabled: true
+  Enabled: pending
   VersionAdded: '0.81'
 
 Lint/SuppressedException:
@@ -3660,7 +3660,7 @@
   Description: When using exponential notation, favor a mantissa between 1 (inclusive)
     and 10 (exclusive).
   StyleGuide: "#exponential-notation"
-  Enabled: true
+  Enabled: pending
   VersionAdded: '0.82'
   EnforcedStyle: scientific
   SupportedStyles:
@@ -3771,7 +3771,7 @@
 Style/HashEachMethods:
   Description: Use Hash#each_key and Hash#each_value.
   StyleGuide: "#hash-each"
-  Enabled: true
+  Enabled: pending
   VersionAdded: '0.80'
   Safe: false
 
@@ -3802,7 +3802,7 @@
 # Supports --auto-correct
 Style/HashTransformKeys:
   Description: Prefer `transform_keys` over `each_with_object`, `map`, or `to_h`.
-  Enabled: true
+  Enabled: pending
   VersionAdded: '0.80'
   VersionChanged: '0.90'
   Safe: false
@@ -3810,7 +3810,7 @@
 # Supports --auto-correct
 Style/HashTransformValues:
   Description: Prefer `transform_values` over `each_with_object`, `map`, or `to_h`.
-  Enabled: true
+  Enabled: pending
   VersionAdded: '0.80'
   VersionChanged: '0.90'
   Safe: false
```

</details>

As you can see, some cops are now displayed as "pending". However, our configuration now keeps them enabled:

https://github.com/cookpad/global-style-guides/blob/7470c0d87765183afca689815d25bc47e6cb73f4/.rubocop.yml#L6-L7

To confirm it, I ran Rubocop on a very short file which contains one of the offenses for which the cop changed from "enabled" to "pending". The change did not affect Rubocop's behaviour, which was the same before and after:

```console
$ cat test.rb
{ a: 1, b: 2 }.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
$ rubocop test.rb
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: Style/HashTransformValues: Prefer transform_values over each_with_object.
{ a: 1, b: 2 }.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense auto-correctable
```