### PR TITLE
Update RSpec README to point to new default branch

### DIFF
--- a/rspec/README.md
+++ b/rspec/README.md
@@ -2,8 +2,8 @@
 
 In general we favor testing behavior and functionality over implementation details. This means we favor writing feature and request specs over unit/model/controller/view specs. For additional testing guidance, see also the READMEs in the spec directories:
 
-- [Feature Specs](https://github.com/cookpad/global-web/blob/master/spec/features/README.md)
-- [Request (API) Specs](https://github.com/cookpad/global-web/blob/master/spec/requests/api/README.md)
+- [Feature Specs](https://github.com/cookpad/global-web/blob/main/spec/features/README.md)
+- [Request (API) Specs](https://github.com/cookpad/global-web/blob/main/spec/requests/api/README.md)
 
 These are some of the conventions we follow:
 


### PR DESCRIPTION
This PR updates README file as the default branch of another project has been changed to `main`.