### PR TITLE
Disable `Lint/MissingSuper` in Rubocop config

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -262,6 +262,9 @@ Lint/RequireParentheses:
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
+Lint/MissingSuper:
+  Enabled: false
+
 Lint/UselessAssignment:
   Exclude:
     - spec/**/*


### PR DESCRIPTION

## What
Disable `Lint/MissingSuper` rule in Rubocop config

## Why

Closes https://github.com/cookpad/web-chapter/issues/644

After enabling the new cops we started getting [`Lint/MissingSuper`](https://github.com/cookpad/global-web/pull/23799/files/fed0457ded3622c100beaec019556eb1c741f8c1#r579801823) when making changes to  the initializers
```
Lint/MissingSuper: Call super to initialize state of the parent class.
```




Following @sikachu's suggestion to disable this rule project-wide to decide whether we want it enabled separately  https://github.com/cookpad/web-chapter/issues/644#issuecomment-783254684