### PR TITLE
Remove unnecessary defaults from .scss-lint.yml

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,250 +1,31 @@
-# Default application configuration that all configurations inherit from.
-
-scss_files: "**/*.scss"
-plugin_directories: ['.scss-linters']
-
-# List of gem names to load custom linters from (make sure they are already
-# installed)
-plugin_gems: []
-
-# Default severity of all linters.
-severity: warning
-
 linters:
-  BangFormat:
-    enabled: true
-    space_before_bang: true
-    space_after_bang: false
-
-  BemDepth:
-    enabled: false
-    max_elements: 1
-
-  BorderZero:
-    enabled: true
-    convention: zero # or `none`
-
-  ChainedClasses:
-    enabled: false
-
-  ColorKeyword:
-    enabled: true
-
-  ColorVariable:
-    enabled: true
-
-  Comment:
-    enabled: true
-    style: silent
-
-  DebugStatement:
-    enabled: true
-
-  DeclarationOrder:
-    enabled: true
-
-  DisableLinterReason:
-    enabled: false
-
-  DuplicateProperty:
-    enabled: true
-
-  ElsePlacement:
-    enabled: true
-    style: same_line # or 'new_line'
-
-  EmptyLineBetweenBlocks:
-    enabled: true
-    ignore_single_line_blocks: true
-
-  EmptyRule:
-    enabled: true
-
-  ExtendDirective:
-    enabled: false
-
-  FinalNewline:
-    enabled: true
-    present: true
-
   HexLength:
     enabled: false
-    style: short # or 'long'
-
-  HexNotation:
-    enabled: true
-    style: lowercase # or 'uppercase'
-
-  HexValidation:
-    enabled: true
-
-  IdSelector:
-    enabled: true
 
   ImportantRule:
     enabled: false
 
-  ImportPath:
-    enabled: true
-    leading_underscore: false
-    filename_extension: false
-
-  Indentation:
-    enabled: true
-    allow_non_nested_indentation: false
-    character: space # or 'tab'
-    width: 2
-
   LeadingZero:
-    enabled: true
-    style: include_zero # or 'exclude_zero'
-
-  MergeableSelector:
-    enabled: true
-    force_nesting: true
-
-  NameFormat:
-    enabled: true
-    allow_leading_underscore: true
-    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+    style: include_zero
 
   NestingDepth:
-    enabled: true
     max_depth: 4
-    ignore_parent_selectors: false
 
   PlaceholderInExtend:
     enabled: false
 
-  PrivateNamingConvention:
-    enabled: false
-    prefix: _
-
   PropertyCount:
     enabled: true
-    include_nested: false
-    max_properties: 10
 
   PropertySortOrder:
     enabled: false
 
-  PropertySpelling:
-    enabled: true
-    extra_properties: []
-    disabled_properties: []
-
-  PropertyUnits:
-    enabled: true
-    global: [
-      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
-      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
-      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
-      'deg', 'grad', 'rad', 'turn',            # Angle
-      'ms', 's',                               # Duration
-      'Hz', 'kHz',                             # Frequency
-      'dpi', 'dpcm', 'dppx',                   # Resolution
-      '%']                                     # Other
-    properties: {}
-
-  PseudoElement:
-    enabled: true
-
-  QualifyingElement:
-    enabled: true
-    allow_element_with_attribute: false
-    allow_element_with_class: false
-    allow_element_with_id: false
-
   SelectorDepth:
-    enabled: true
     max_depth: 2
 
   SelectorFormat:
-    enabled: true
-    convention: hyphenated_BEM # or 'hyphenated_lowercase', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+    convention: hyphenated_BEM
     ignored_names: ['form-control', 'modal-body', 'modal-content', 'modal-header', 'input-group', 'btn-gplus', 'btn-facebook', 'btn-twitter', 'btn-following']
 
-  Shorthand:
-    enabled: true
-
-  SingleLinePerProperty:
-    enabled: true
-    allow_single_line_rule_sets: true
-
-  SingleLinePerSelector:
-    enabled: true
-
-  SpaceAfterComma:
-    enabled: true
-    style: one_space # or 'no_space', or 'at_least_one_space'
-
-  SpaceAfterPropertyColon:
-    enabled: true
-    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
-
-  SpaceAfterPropertyName:
-    enabled: true
-
-  SpaceAfterVariableColon:
-    enabled: false
-    style: one_space # or 'no_space', 'at_least_one_space' or 'one_space_or_newline'
-
-  SpaceAfterVariableName:
-    enabled: true
-
-  SpaceAroundOperator:
-    enabled: true
-    style: one_space # or 'at_least_one_space', or 'no_space'
-
-  SpaceBeforeBrace:
-    enabled: true
-    style: space # or 'new_line'
-    allow_single_line_padding: false
-
-  SpaceBetweenParens:
-    enabled: true
-    spaces: 0
-
   StringQuotes:
-    enabled: true
-    style: double_quotes # or single_quotes
-
-  TrailingSemicolon:
-    enabled: true
-
-  TrailingWhitespace:
-    enabled: true
-
-  TrailingZero:
-    enabled: false
-
-  TransitionAll:
-    enabled: false
-
-  UnnecessaryMantissa:
-    enabled: true
-
-  UnnecessaryParentReference:
-    enabled: true
-
-  UrlFormat:
-    enabled: true
-
-  UrlQuotes:
-    enabled: true
-
-  VariableForProperty:
-    enabled: false
-    properties: []
-
-  VendorPrefix:
-    enabled: true
-    identifier_list: base
-    additional_identifiers: []
-    excluded_identifiers: []
-
-  ZeroUnit:
-    enabled: true
-
-  Compass::*:
-    enabled: false
+    style: double_quotes


### PR DESCRIPTION
# What

This PR simplifies our `.scss-lint.yml` file so that it only keeps settings that have been overridden from the defaults.

# Why

[I was trying to figure out the origin of a rule while reviewing a PR.](https://github.com/cookpad/global-web/pull/23852/files/d17844426b33fcc40d36e1b64f57a9c6d155de38#r586023478)

It turns out that the value we currently have may have been accidentally set when we [updated SCSS-lint's defaults](https://github.com/cookpad/global-web/pull/4433):

> I tried to preserve our exceptions during the merge, but apologies if any weird 🐶 comments show up after we get this in master

Updating defaults from upstream looks like a chore, prone to errors, and something that we shouldn't really need to do, especially as all configurations inherit from the defaults: 😅 
https://github.com/cookpad/global-style-guides/blob/897503ec015086d5218214b88d864d32b528b628/.scss-lint.yml#L1

In the spirit of keeping things concise and maintainable, I thought it would make sense to remove all default fluff from our configuration.

As a beneficial side-effect, it allows us to visualize very easily what rules we have actively decided to tweak, and what others are just defaults that could benefit from having a conversation.

# How

I used `diff` between SCSS-lint's [default.yml](https://github.com/sds/scss-lint/blob/master/config/default.yml) file and our current [`.scss-lint.yml`](https://github.com/cookpad/global-style-guides/blob/main/.scss-lint.yml), and tried to keep only what was different.

To confirm that my changes did not have any impact, I ran `scss-lint` on global-web before and after the changes, then confirmed there were no changes in output:
```console
> cd global-web
> wget https://raw.githubusercontent.com/cookpad/global-style-guides/main/.scss-lint.yml
> scss-lint > before.log
> wget https://raw.githubusercontent.com/cookpad/global-style-guides/ds/remove-unnecessary-defaults-from-scss-lint-yml/.scss-lint.yml
> scss-lint > after.log
> diff before.log after.log
# Empty
```
(I also confirmed that the file is used by running `scss-lint` without it and checking the output is way longer.)

# Anything else?

I took a few liberties in adapting to new defaults when I noticed a discrepancy between our file and the most recent defaults:

- `fr` `PropertyUnits` were [introduced](https://github.com/sds/scss-lint/blob/master/config/default.yml#L145) in the defaults.
- I cleaned up trailing comments that show alternatives: we can check SCSS-lint's defaults.yml to see them
- we could also restore `SelectorDepth`'s `max_depth` to 4, as its change back to 2 might have been an accident, but I thought this might fit better in its own PR (maybe we're actually happy with using `2` now?)

Also, I understand that we need this a lot less now, as with the introduction of both TailwindCSS and Prettier, we should be writing less CSS, and caring less about its linting, but I think that as long as we intend to keep the configuration file in this repository, cleaning it up and making it reflect our explicit choices is useful.