### PR TITLE
Restore SCSS SelectorDepth max to 4

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -21,7 +21,7 @@ linters:
     enabled: false
 
   SelectorDepth:
-    max_depth: 2
+    max_depth: 4
 
   SelectorFormat:
     convention: hyphenated_BEM


### PR DESCRIPTION
## What

This sets the maximum nesting of selectors to 4, as it [used to be](https://github.com/cookpad/global-web/pull/4433/files#diff-ebef2f6706bbb40d0612571ca7f67fdf84ad7666e525d0572a35a090b7afe9a9R160).

## Why

You'll find a more complete explanation in my previous PR: [Remove unnecessary defaults from .scss-lint.yml](https://github.com/cookpad/global-style-guides/pull/184).
In brief, we used to have this tweaked to `4` but it appears that setting was lost when we [brought new defaults from upstream](https://github.com/cookpad/global-web/pull/4433).

## Anything else?

It looks like we've been ignoring the error thrown to us by Hound/Pronto for a while:

![image](https://user-images.githubusercontent.com/816901/109924837-42439a80-7d04-11eb-8cec-860e26dce25f.png)

This change reduces the number of warnings for this linter from 323 to 42.