### PR TITLE
Update rubocop rule for Gemfile

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -1,3 +1,6 @@
+Bundler/OrderedGems:
+  ConsiderPunctuation: true
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
@@ -11,6 +14,7 @@ Layout/LineLength:
   AllowURI: true
   Max: 120
   Exclude:
+    - Gemfile
     - spec/**/*
 
 Metrics/ModuleLength:


### PR DESCRIPTION
I noticed that when I open `Gemfile` for editing, [ALE](https://github.com/dense-analysis/ale) would flag a few lines for Rubocop violations, so this PR is updating rule to reflect the way we want to style our Gemfile.

## Enable `ConsiderPunctuation` for `Bundler/OrderedGems` so we can use `:sort`.

This `Bundler/OrderedGems` Cop is actually enabled by default from [Rubocop](https://docs.rubocop.org/rubocop/cops_bundler.html#bundlerorderedgems). However, by default, it enables with `ConsiderPunctuation` as false. This means that by default this is considered a violation, despite this is what you get from doing `:sort` in VIM.

```ruby
  gem "rspec-instafail", require: false
  gem "rspec-rails"
  gem "rspec_api_documentation", github: "zipmark/rspec_api_documentation", branch: "master"
```

By enable `ConsiderPunctuation`, this is now correct as `-` comes before `_`.

## Exclude `Gemfile` from `Layout/LineLength` so having a long comment in a Gemfile entry won't be a violation.

In our projects, we have a few lines in `Gemfile` that goes over 120 characters because we want to keep a link to the explanation on why we need to fork or freeze a particular gem on the same line as the `gem` entry. Since we don't care about the line length in the `Gemfile`, we should adjust our rule to accommodate it.