### PR TITLE
[RFC] Disable Rails/ContentTag

### DIFF
--- a/.rubocop.rails.yml
+++ b/.rubocop.rails.yml
@@ -22,3 +22,6 @@ Rails/RequestReferer:
 
 Rails/DynamicFindBy:
   Enabled: false
+
+Rails/ContentTag:
+  Enabled: false


### PR DESCRIPTION
### What

Disable the Rails/ContentTag cop.

### Why

There is an [open PR](https://github.com/rubocop/rubocop-rails/issues/260) for Rubocop that makes a pretty compelling argument that this cop targets the wrong method.

And you can see in the Rails docs that there is a legacy syntax section for the [#tag method](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag) but no deprecation or legacy syntax is mentioned for [#content_tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag).

cc: @cookpad/web-chapter 