### PR TITLE
Rephrase RSpec style guide rule on matchers

### DIFF
--- a/rspec/README.md
+++ b/rspec/README.md
@@ -432,7 +432,7 @@ These are some of the conventions we follow:
     ```
   </details>
 - <a name="built-in-matcher"></a>
-  Prefer using [built-in matchers](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers) over `be_truthy` or `be_falsey`.
+  Prefer using more descriptive [built-in matchers](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers) over the general `be_truthy` or `eql(true)`.
   <sup>[link](#built-in-matcher)</sup>
 
   <details>
@@ -445,9 +445,9 @@ These are some of the conventions we follow:
     #  expected: truthy value
     #       got: false
 
-    expect(Achievement.unseen.exist?).to be_falsey
+    expect(Achievement.unseen.exist?).to eql(false)
 
-    #  expected: falsey value
+    #  expected: false
     #       got: true
 
     ## Good


### PR DESCRIPTION
## What 

Rephrase RSpec stye guide rule on built-in matchers.

New phrasing places emphasis on the matcher descriptiveness, and not whether they are built-in to RSpec or not. 

## Why 

Current phrasing is unclear. Suggests `be_truthy` and `be_falsey` should be avoided because they are not built-in matchers, but they are.

https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers

## How 

Rephrase rule.