### PR TITLE
Add RSpec style guide rule for code that tests our test tools.

### DIFF
--- a/rspec/README.md
+++ b/rspec/README.md
@@ -515,3 +515,24 @@ These are some of the conventions we follow:
     end
     ```
   </details>
+- <a name="#test-code-specs"></a>
+  Use `.spec` as the file extension when writing tests for code that is part of the test suite.
+  <sup>[link](#test-code-specs) </sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ``` ruby
+    ## Bad
+    # spec/matchers/my_custom_matcher_spec.rb
+    RSpec.describe MyCustomMatcher do
+      # ...
+    end
+  
+    ## Good
+    # spec/matchers/my_custom_matcher_spec.spec
+    RSpec.describe MyCustomMatcher do
+      # ...
+    end
+    ```
+  </details>


### PR DESCRIPTION
I've added a new suggestion to our RSpec style guide.

Recently, when adding custom matchers to the test suite, I felt that the behaviour of these was complex enough that it warranted its own tests.

Since these files were in `spec/support`, they were being loaded automatically in `rails_helper.rb` each time the specs are run—even when only running an isolated example.

This is, of course, caused by the boilerplate line:

``` ruby 
Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
```

My solution to dealing with this was to use the `spec` extension. I think it would be sensible if we use this extension type for all tests that specifically test code that's part of the test suite.

Feedback welcome!