### PR TITLE
Do not enforce Hash shorthand syntax in Ruby

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -297,3 +297,7 @@ Style/PercentLiteralDelimiters:
 
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: required
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+  


### PR DESCRIPTION
## What 

This PR adds a new Rubocop directive to prevent automatic enforcement of the hash shorthand syntax in Ruby.

## Why

Ruby 3.1 has added a [new shorthand syntax for hashes](https://bugs.ruby-lang.org/issues/17292), similar to Javascript's object shorthand.

``` ruby 
##
# This 
def one
  1
end 

two = 2

my_hash = { one: one, two: two} # => { one: 1, two: 2 }

##
# Can now be stated as
def one
  1
end 

two = 2

my_hash = { one:, two:} # => { one: 1, two: 2 }
```
_(Note: The hash in the final line does not have to explicitly name the method and local variables, since they share the same name as the hash keys)._

The default behavior in newer versions of Rubocop is to enforce this style wherever possible. [See this commit](https://github.com/rubocop/rubocop/commit/d85a3c496e0077b2fafa4862937ff472015e094e).

I think we need to discuss as a team: 
1. Whether we want to adopt this new shorthand syntax or not? (Happy to discuss in this PR)
2. Do we want Rubocop to automatically update existing code to use this new syntax or not?

## How 

For now, I've disabled this syntax in the Rubocop config file, to ensure our current code still passes linting.

cc: @cookpad/global-web-devs-all 