### PR TITLE
Sort Rubocop Rails directives in alphabetical order

### DIFF
--- a/.rubocop.rails.yml
+++ b/.rubocop.rails.yml
@@ -6,19 +6,19 @@ Rails/ActionFilter:
 Rails/Delegate:
   Enabled: false
 
+Rails/DynamicFindBy:
+  Enabled: false
+
 Rails/Output:
   Include:
-    - app/**/*.rb
-    - config/**/*.rb
-    - db/**/*.rb
-    - lib/**/*.rb
-    - spec/**/*.rb
-
-Rails/SkipsModelValidations:
-  Enabled: false
+  - app/**/*.rb
+  - config/**/*.rb
+  - db/**/*.rb
+  - lib/**/*.rb
+  - spec/**/*.rb
 
 Rails/RequestReferer:
   EnforcedStyle: referrer
 
-Rails/DynamicFindBy:
+Rails/SkipsModelValidations:
   Enabled: false

--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -1,27 +1,120 @@
 Bundler/OrderedGems:
   ConsiderPunctuation: true
 
-Metrics/BlockLength:
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ConditionPosition:
+  Enabled: false
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/EmptyLines:
   Exclude:
-    - spec/**/*.rb
-    - config/**/*.rb
-    - db/migrate/*.rb
-    - lib/tasks/**/*.rake
-    - Gemfile
+  - spec/**/*
+
+Layout/IndentationConsistency:
+  EnforcedStyle: indented_internal_methods
 
 Layout/LineLength:
   AllowHeredoc: true
   AllowURI: true
   Max: 120
   Exclude:
-    - Gemfile
-    - spec/**/*
+  - Gemfile
+  - spec/**/*
+
+Lint/AmbiguousOperator:
+  Enabled: false
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/DeprecatedClassMethods:
+  Enabled: false
+
+Lint/ElseLayout:
+  Enabled: false
+
+Lint/FlipFlop:
+  Enabled: false
+
+Lint/LiteralInInterpolation:
+  Enabled: false
+
+Lint/Loop:
+  Enabled: false
+
+Lint/MissingSuper:
+  Enabled: false
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RequireParentheses:
+  Enabled: false
+
+Lint/SuppressedException:
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UselessAssignment:
+  Exclude:
+  - spec/**/*
+
+Metrics/BlockLength:
+  Exclude:
+  - spec/**/*.rb
+  - config/**/*.rb
+  - db/migrate/*.rb
+  - lib/tasks/**/*.rake
+  - Gemfile
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
 
 Metrics/ModuleLength:
   Exclude:
-    - spec/**/*
+  - spec/**/*
+
+Metrics/ParameterLists:
+  Enabled: false
 
 Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/AsciiIdentifiers:
+  Enabled: false
+
+Naming/FileName:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: required
+
+Naming/PredicateName:
+  ForbiddenPrefixes:
+  - is_
+
+Naming/VariableNumber:
   Enabled: false
 
 Style/Alias:
@@ -33,13 +126,7 @@ Style/ArrayJoin:
 Style/AsciiComments:
   Enabled: false
 
-Naming/AsciiIdentifiers:
-  Enabled: false
-
 Style/Attr:
-  Enabled: false
-
-Metrics/BlockNesting:
   Enabled: false
 
 Style/CaseEquality:
@@ -49,9 +136,6 @@ Style/CharacterLiteral:
   Enabled: false
 
 Style/ClassAndModuleChildren:
-  Enabled: false
-
-Metrics/ClassLength:
   Enabled: false
 
 Style/ClassVars:
@@ -70,14 +154,8 @@ Style/ColonMethodCall:
 Style/CommentAnnotation:
   Enabled: false
 
-Metrics/CyclomaticComplexity:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
-
-Layout/DotPosition:
-  EnforcedStyle: trailing
 
 Style/DoubleNegation:
   Enabled: false
@@ -94,14 +172,11 @@ Style/Encoding:
 Style/EvenOdd:
   Enabled: false
 
-Naming/FileName:
-  Enabled: false
-
-Lint/FlipFlop:
-  Enabled: false
-
 Style/FormatString:
   Enabled: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template
 
 Style/FrozenStringLiteralComment:
   Enabled: false
@@ -118,9 +193,6 @@ Style/IfUnlessModifier:
 Style/IfWithSemicolon:
   Enabled: false
 
-Layout/IndentationConsistency:
-  EnforcedStyle: indented_internal_methods
-
 Style/InlineComment:
   Enabled: false
 
@@ -131,9 +203,6 @@ Style/LambdaCall:
   Enabled: false
 
 Style/LineEndConcatenation:
-  Enabled: false
-
-Metrics/MethodLength:
   Enabled: false
 
 Style/ModuleFunction:
@@ -154,21 +223,29 @@ Style/NilComparison:
 Style/NumericLiterals:
   Enabled: false
 
+Style/NumericPredicate:
+  EnforcedStyle: comparison
+
 Style/OneLineConditional:
   Enabled: false
 
 Style/ParallelAssignment:
   Enabled: false
 
-Metrics/ParameterLists:
-  Enabled: false
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%": "()"
+    "%i": "()"
+    "%q": "()"
+    "%Q": "()"
+    "%r": "{}"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
 
 Style/PerlBackrefs:
   Enabled: false
-
-Naming/PredicateName:
-  ForbiddenPrefixes:
-    - is_
 
 Style/Proc:
   Enabled: false
@@ -182,13 +259,13 @@ Style/RegexpLiteral:
 Style/SelfAssignment:
   Enabled: false
 
+Style/SignalException:
+  Enabled: false
+
 Style/SingleLineBlockParams:
   Enabled: false
 
 Style/SingleLineMethods:
-  Enabled: false
-
-Style/SignalException:
   Enabled: false
 
 Style/SpecialGlobalVars:
@@ -197,25 +274,16 @@ Style/SpecialGlobalVars:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
+
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: no_comma
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: no_comma
 
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: no_comma
-
-Style/FormatStringToken:
-  EnforcedStyle: template
-
 Style/TrivialAccessors:
-  Enabled: false
-
-Lint/UnusedMethodArgument:
-  Enabled: false
-
-Naming/VariableNumber:
   Enabled: false
 
 Style/VariableInterpolation:
@@ -229,71 +297,3 @@ Style/WhileUntilModifier:
 
 Style/WordArray:
   Enabled: false
-
-Lint/AmbiguousOperator:
-  Enabled: false
-
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
-Lint/AssignmentInCondition:
-  Enabled: false
-
-Layout/ConditionPosition:
-  Enabled: false
-
-Lint/DeprecatedClassMethods:
-  Enabled: false
-
-Lint/ElseLayout:
-  Enabled: false
-
-Lint/SuppressedException:
-  Enabled: false
-
-Lint/LiteralInInterpolation:
-  Enabled: false
-
-Lint/Loop:
-  Enabled: false
-
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
-
-Lint/RequireParentheses:
-  Enabled: false
-
-Lint/UnderscorePrefixedVariableName:
-  Enabled: false
-
-Lint/MissingSuper:
-  Enabled: false
-
-Lint/UselessAssignment:
-  Exclude:
-    - spec/**/*
-
-Layout/ArgumentAlignment:
-  EnforcedStyle: with_fixed_indentation
-
-Layout/EmptyLines:
-  Exclude:
-    - spec/**/*
-
-Style/NumericPredicate:
-  EnforcedStyle: comparison
-
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    "%":  ()
-    "%i": ()
-    "%q": ()
-    "%Q": ()
-    "%r": "{}"
-    "%s": ()
-    "%w": ()
-    "%W": ()
-    "%x": ()
-
-Naming/MemoizedInstanceVariableName:
-  EnforcedStyleForLeadingUnderscores: required


### PR DESCRIPTION
Sort Rubocop Rails directives in alphabetical order

As in #193, I've sorted the Rubocop directives in alphabetical order.
