### PR TITLE
Enable Hash shorthand syntax - accept both new and old syntax

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -188,7 +188,7 @@ Style/GuardClause:
   Enabled: false
 
 Style/HashSyntax:
-  EnforcedShorthandSyntax: never
+  EnforcedShorthandSyntax: consistent
 
 Style/IfUnlessModifier:
   Enabled: false


### PR DESCRIPTION
This enables both type of hash syntax:

```ruby
#bad 
{foo: , bar: bar}

#bad
{foo: , bar: baz}

#good
{foo:, bar:} # shorthand syntax

#good
{foo: foo, bar: baz} # old/currnet syntax
```

Source: https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax

See my arguments for this 👇