### PR TITLE
Avoid excessive numbered params in a single block

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -223,6 +223,10 @@ Style/Next:
 Style/NilComparison:
   Enabled: false
 
+Style/NumberedParameters:
+  Enabled: true
+  EnforcedStyle: allow_single_line
+
 Style/NumberedParametersLimit:
   Enabled: true
   Max: 1

--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -223,6 +223,10 @@ Style/Next:
 Style/NilComparison:
   Enabled: false
 
+Style/NumberedParametersLimit:
+  Enabled: true
+  Max: 1
+
 Style/NumericLiterals:
   Enabled: false
 


### PR DESCRIPTION
## What

Avoid excessive numbered params in a single block

```
# bad
foo { _1.call(_2, _3, _4) }

# good
foo { do_something(_1) }
```

## Why

Detects the use of an excessive amount of numbered parameters in a single block. Having too many numbered parameters can make code too cryptic and hard to read.

cc @cookpad/global-rails 