### PR TITLE
Enable Lint/AssignmentInCondition

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -31,9 +31,6 @@ Lint/AmbiguousOperator:
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-Lint/AssignmentInCondition:
-  Enabled: false
-
 Lint/DeprecatedClassMethods:
   Enabled: false
 


### PR DESCRIPTION
Let's enable (set the default value for) the cop "[Lint/AssignmentInCondition](https://docs.rubocop.org/rubocop/cops_lint.html#lintassignmentincondition)". It was probably disabled when we started using RuboCop to keep compatibility with the code at that time.

With the default value, it allows you to keep the assignment in the condition if you wrap it in parenthesis:

```
Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
```