### PR TITLE
Fix rubocop-rspec configuration

### DIFF
--- a/.rubocop.rspec.yml
+++ b/.rubocop.rspec.yml
@@ -1,7 +1,8 @@
 require: rubocop-rspec
 
-AllCops:
-  DisabledByDefault: true
+RSpec:
+  Enabled: false
 
 RSpec/DescribedClass:
+  Enabled: true
   EnforcedStyle: explicit


### PR DESCRIPTION
In #198 I wanted to enable the `Lint/AssignmentInCondition` cop by deleting its configuration since it is enabled by default. However, I noticed that RuboCop was still not showing any warnings in our codebase.

After a while of debugging, I noticed that the recent configuration file for `rubocop-rspec` was disabling **ALL** cops by default, while the intention was to disable only those for RSpec.

The correct way to enable/disable an entire "department" is the one I've used in this PR, as explained in the [RuboCop documentation](https://docs.rubocop.org/rubocop/configuration.html#generic-configuration-parameters)

Also, the one RSpec cop we wanted to enable was not actually enabled, as it was missing `Enabled: true`