### PR TITLE
Disable Conditional Safe Assignment

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -26,7 +26,7 @@ Layout/LineLength:
   - spec/**/*
 
 Lint/AllowSafeAssignment:
-  Enabled: False
+  Enabled: false
 
 Lint/AmbiguousOperator:
   Enabled: false

--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -25,6 +25,9 @@ Layout/LineLength:
   - Gemfile
   - spec/**/*
 
+Lint/AllowSafeAssignment:
+  Enabled: False
+
 Lint/AmbiguousOperator:
   Enabled: false
 


### PR DESCRIPTION
## What
Disable Conditional Safe Assignment

## Why

Assignments in conditional assignments can be confused with the boolean operation, for the code author and reviewers.

## How

Disabling Safe assignments in conditionals we can improve the readability of the code by keeping assignments and conditions in separate lines.

## Anything else

Since Ruby 2.0 this type of conditional statement raise warnings in the console https://github.com/ruby/ruby/commit/e672994d146

cc @cookpad/global-rails 