### PR TITLE
Fix AllowSafeAssigment

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -25,8 +25,9 @@ Layout/LineLength:
   - Gemfile
   - spec/**/*
 
-Lint/AllowSafeAssignment:
-  Enabled: false
+Lint/AssignmentInCondition:
+  Enabled: true
+  AllowSafeAssignment: false
 
 Lint/AmbiguousOperator:
   Enabled: false


### PR DESCRIPTION
`AllowSafeAssignment` is an option of `Lint/AssignmentInCondition`, not a cop by itself.