### PR TITLE
Disable Rails/I18nLazyLookup because it goes against our guides

### DIFF
--- a/.rubocop.rails.yml
+++ b/.rubocop.rails.yml
@@ -9,6 +9,9 @@ Rails/Delegate:
 Rails/DynamicFindBy:
   Enabled: false
 
+Rails/I18nLazyLookup:
+  Enabled: false
+
 Rails/Output:
   Include:
   - app/**/*.rb


### PR DESCRIPTION
This will disable `Rails/I18nLazyLookup`.

It seems that starting with November 2022 [this PR](https://github.com/rubocop/rubocop-rails/pull/850) was merged to Rails Rubocop that fixes the way `Rails/I18nLazyLookup`


But this cop goes against our style guide rule: 
https://github.com/cookpad/global-style-guides/tree/main/rails#use-fully-qualified