### PR TITLE
Disable Rails/I18nLazyLookup rule

### DIFF
--- a/.rubocop.rails.yml
+++ b/.rubocop.rails.yml
@@ -22,3 +22,6 @@ Rails/RequestReferer:
 
 Rails/SkipsModelValidations:
   Enabled: false
+
+Rails/I18nLazyLookup:
+  Enabled: false


### PR DESCRIPTION
Disables [this rule](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsi18nlazylookup) because it contradicts [this](https://github.com/cookpad/global-style-guides/tree/main/rails#use-fully-qualified) part of our styleguide:
> Use fully qualified i18n name. eg. recipes.show.title rather than shorthand .title

The Rubocop rule requires us to use the shorthand where `I18n` can automatically infer the full phrase key. But[^1] we prefer to explicitly specify the full key.

[^1]: As of [this change](https://github.com/cookpad/global-style-guides/pull/2/files)