### PR TITLE
Disabled SuggestExtensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,4 @@ inherit_from:
 
 AllCops:
   NewCops: enable
+  SuggestExtensions: false


### PR DESCRIPTION
## Why:

Rubocop SuggestedExtensions displays a message like

`
The following RuboCop extension libraries are installed but not loaded in config: 
`

every time Rubocop is run. 

If you run Rubocop on multiple files this message will be printed each time Rubocop runs, thus making the output of the analysis hard to follow.

I think it is better to let the output of Rubocop remain focused on reporting offences.