### PR TITLE
Enable Style/GuardClause

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -185,9 +185,6 @@ Style/FrozenStringLiteralComment:
 Style/GlobalVars:
   Enabled: false
 
-Style/GuardClause:
-  Enabled: false
-
 Style/HashSyntax:
   EnforcedShorthandSyntax: consistent
 


### PR DESCRIPTION
We want to enable [Style/GuardClause](https://docs.rubocop.org/rubocop/cops_style.html#styleguardclause) to make code easier to read and maintain. Guard clauses handle edge cases upfront, reducing nesting and making the "happy path" more transparent. This simplifies the code and makes it more approachable for new contributors. It also decreases the cognitive load for developers.


... and because we all :heart: guard clauses, don't we? 😄 