### PR TITLE
Update RuboCop config for 1.8 compatibility

### DIFF
--- a/.rubocop.performance.yml
+++ b/.rubocop.performance.yml
@@ -1,4 +1,4 @@
-require: rubocop-performance
+plugins: rubocop-performance
 
 Performance/RedundantMerge:
   Enabled: false

--- a/.rubocop.rails.yml
+++ b/.rubocop.rails.yml
@@ -1,4 +1,4 @@
-require: rubocop-rails
+plugins: rubocop-rails
 
 Rails/ActionFilter:
   Enabled: false

--- a/.rubocop.rspec.yml
+++ b/.rubocop.rspec.yml
@@ -1,4 +1,4 @@
-require: rubocop-rspec
+plugins: rubocop-rspec
 
 RSpec:
   Enabled: false

--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -111,7 +111,7 @@ Naming/FileName:
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: required
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   ForbiddenPrefixes:
   - is_
 


### PR DESCRIPTION
RuboCop has recently released version 1.8, which triggers new warnings with our current configuration:

- The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
- The `rubocop-rails`, `rubocop-performance`, and `rubocop-rspec` extensions now support plugins. You should specify `plugins: ...` instead of `require: ...` in your configuration files.  
  See: https://docs.rubocop.org/rubocop/plugin_migration_guide.html

To address these, I have created a `rubocop-1.8` branch containing the necessary adjustments.

This pull request will not be merged immediately; we will wait until our main applications have upgraded to RuboCop 1.8.  
If you want to use RuboCop 1.8 in your project before then, update the `inherit_from` attribute in your `.rubocop.yml` to point to the `rubocop-1.8` branch:

```yaml
inherit_from:
  - https://raw.githubusercontent.com/cookpad/global-style-guides/rubocop-1.8/.rubocop.yml
```